### PR TITLE
Add CLAUDE.md and specifications index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A Code Review Plugin for Claude Code that enables generalist software engineers to extend their review capability across Architecture, Security, Site Reliability Engineering (SRE), and Data Engineering disciplines. The plugin provides slash commands (`review-all`, `review-sec`, `review-sre`, `review-arch`, `review-data`) that perform domain-specific code reviews with progressive level reporting.
+
+## Git Workflow
+
+- **Never commit directly to `main`** — pre-commit and pre-push hooks enforce this
+- Create feature branches: `git checkout -b feat/<description>`
+- Push feature branches and create PRs against `main`
+- Branch naming convention: `feat/`, `fix/`, `chore/` prefixes

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,18 @@
+# Specifications index
+
+This file provides guidance on where to find standards and specifications for this project.
+
+- Claude best practices and prompting tips: https://code.claude.com/docs/en/best-practices
+- Claude Plugins: https://code.claude.com/docs/en/plugins and https://code.claude.com/docs/en/plugins-reference
+- Claude Plugin Marketplace: https://code.claude.com/docs/en/plugin-marketplaces
+- Agents: https://code.claude.com/docs/en/sub-agents
+- Agent teams: https://code.claude.com/docs/en/agent-teams
+- Skills and slash commands: https://code.claude.com/docs/en/skills
+- Hooks: https://code.claude.com/docs/en/hooks-guide
+- MCP: https://code.claude.com/docs/en/mcp
+- Output styles: https://code.claude.com/docs/en/output-styles
+- Claude Configuration and Settings: https://code.claude.com/docs/en/settings
+- Claude Permissions models: https://code.claude.com/docs/en/permissions
+- Claude Sandbox configuration: https://code.claude.com/docs/en/sandboxing
+
+- SRE, Site Reliability Engineering, Availability, Observability, Incident Response, CI/CD, Deployment - ./sre-spec.md


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project overview and git workflow guidance for Claude Code
- Add `spec/README.md` as a specifications index linking to Claude plugin documentation and domain-specific review specs

## Test plan
- [ ] Verify CLAUDE.md renders correctly and accurately describes the project
- [ ] Verify spec/README.md links are correct and the SRE spec reference is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)