### PR TITLE
Add SRE domain specification

### DIFF
--- a/spec/sre-spec.md
+++ b/spec/sre-spec.md
@@ -1,0 +1,3 @@
+# SRE Spec
+
+TODO - Complete this specification.

--- a/spec/sre/anti-patterns.md
+++ b/spec/sre/anti-patterns.md
@@ -1,0 +1,363 @@
+# Anti-Patterns Catalogue — SRE Domain
+
+> Complete catalogue of code patterns that SRE reviewers should flag. Organised by ROAD pillar, with SEEMS/FaCTOR classification and typical severity.
+
+## How to use this document
+
+Each anti-pattern includes:
+- **Pattern name** — a short, memorable label
+- **What it looks like** — concrete code description
+- **Why it's bad** — production impact
+- **SEEMS/FaCTOR** — which failure mode and which missing resilience property
+- **Typical severity** — default assessment (may be higher or lower depending on context)
+
+When adding new anti-patterns to prompts, follow this structure. Use concrete descriptions, not abstract categories.
+
+---
+
+## Response Pillar Anti-Patterns
+
+### RP-01: Generic error message
+
+**What it looks like:** Error responses that say "An error occurred", "Something went wrong", "Internal server error" with no additional context.
+
+**Why it's bad:** On-call engineers cannot distinguish a config error from a dependency failure from a code bug. Every incident starts with "read the code" instead of "read the error".
+
+**SEEMS:** Misconfiguration (can't diagnose config errors)
+**FaCTOR:** Fault isolation (failure not attributed to correct component)
+**Typical severity:** MEDIUM / L1
+
+### RP-02: Swallowed exception
+
+**What it looks like:** `catch (Exception e) { }` or `except Exception: pass` — exception caught with no logging, no re-throw, no metric.
+
+**Why it's bad:** The failure is invisible. Upstream callers may believe the operation succeeded. Data can be silently lost.
+
+**SEEMS:** Misconfiguration (failure is undiagnosable)
+**FaCTOR:** Output correctness (caller gets wrong signal about success/failure)
+**Typical severity:** HIGH / HYG (Irreversible — if the swallowed error masks data loss)
+
+### RP-03: Stack trace in API response
+
+**What it looks like:** Exception stack traces returned in HTTP response bodies to external callers.
+
+**Why it's bad:** Exposes internal implementation details. May contain file paths, dependency names, or connection strings. Unhelpful to API consumers.
+
+**SEEMS:** Misconfiguration (error output misconfigured)
+**FaCTOR:** Output correctness (error response is not well-formed)
+**Typical severity:** MEDIUM / L1 (escalates to HYG if stack trace contains credentials or PII)
+
+### RP-04: Missing correlation IDs
+
+**What it looks like:** Logs from different services or different operations within a request have no shared identifier. No request ID, no trace ID, no correlation token.
+
+**Why it's bad:** When a user reports a problem, operators cannot trace the request through the system. Diagnosis requires time-based log correlation (error-prone and slow).
+
+**SEEMS:** Shared fate (cross-service failure diagnosis impossible)
+**FaCTOR:** Fault isolation (cannot attribute failure to originating component)
+**Typical severity:** MEDIUM / L1
+
+### RP-05: No error classification
+
+**What it looks like:** All errors treated the same — no distinction between retryable (timeout, rate limit) and permanent (bad request, not found) errors.
+
+**Why it's bad:** Clients retry permanent errors (wasting resources) or give up on retryable errors (unnecessary failure). Automated retry logic can't make correct decisions.
+
+**SEEMS:** Excessive load (retrying permanent errors amplifies load)
+**FaCTOR:** Output correctness (error semantics don't guide correct client behaviour)
+**Typical severity:** MEDIUM / L1
+
+### RP-06: Errors require code reading
+
+**What it looks like:** Error messages reference internal variable names, enum values, or error codes that only make sense if you've read the source code. E.g., "ERR_STATE_7" or "InvalidTransition: state=PENDING_REVIEW".
+
+**Why it's bad:** On-call engineers (who may not have written the code) cannot understand the error without finding and reading the relevant source file.
+
+**SEEMS:** Misconfiguration (cannot diagnose without code access)
+**FaCTOR:** Fault isolation (failure diagnosis blocked by indirection)
+**Typical severity:** LOW / L1
+
+---
+
+## Observability Pillar Anti-Patterns
+
+### OP-01: Print/console.log instead of structured logging
+
+**What it looks like:** `print(f"Processing order {order_id}")` or `console.log("Error:", err)` — unstructured text output.
+
+**Why it's bad:** No log level (can't filter errors from debug), no structured fields (can't query), no correlation (can't trace), no standard format (can't parse).
+
+**SEEMS:** Misconfiguration (can't diagnose from logs)
+**FaCTOR:** Timeliness (can't measure from log signals)
+**Typical severity:** MEDIUM / L1
+
+### OP-02: Logging entire objects
+
+**What it looks like:** `logger.info("Request received", extra={"request": request.__dict__})` — serialising full objects into logs.
+
+**Why it's bad:** PII risk (user data, passwords, tokens may be in the object). Log bloat (large objects generate kilobytes per log line). Performance impact in hot paths.
+
+**SEEMS:** Misconfiguration (PII exposure)
+**FaCTOR:** Capacity (log volume can overwhelm log infrastructure)
+**Typical severity:** MEDIUM / L1 (escalates to HYG if PII is logged — Regulated)
+
+### OP-03: Unbounded metric cardinality
+
+**What it looks like:** Metric labels that use unbounded values: `user_id`, `request_path` (with path parameters), `session_id`, `order_id`.
+
+**Why it's bad:** Each unique label combination creates a new time series. Unbounded cardinality exhausts the metrics backend's memory and storage, eventually crashing the monitoring system.
+
+**SEEMS:** Excessive load (amplifies monitoring infrastructure load)
+**FaCTOR:** Capacity (monitoring system resource limits exceeded)
+**Typical severity:** HIGH / L2 (escalates to HYG if the metrics backend is shared — Total)
+
+### OP-04: Missing units on metrics
+
+**What it looks like:** `metrics.histogram("request_duration", duration)` — no indication whether `duration` is in milliseconds, seconds, or nanoseconds.
+
+**Why it's bad:** Dashboards and alerts are misconfigured. A "500ms" SLO alert triggers on a value that's actually 500 nanoseconds, or misses a 500-second value.
+
+**SEEMS:** Misconfiguration (metric misinterpretation)
+**FaCTOR:** Timeliness (SLO measurement is wrong)
+**Typical severity:** LOW / L2
+
+### OP-05: Tracing only happy paths
+
+**What it looks like:** Trace spans created for successful operations but not for error paths. Errors don't set span status or record exception details.
+
+**Why it's bad:** The failures you most need to trace are invisible in the tracing system. The tracing tool shows the request started but not why it failed.
+
+**SEEMS:** Misconfiguration (can't diagnose failures from traces)
+**FaCTOR:** Fault isolation (can't attribute failure to correct span)
+**Typical severity:** MEDIUM / L2
+
+### OP-06: No user-to-system correlation
+
+**What it looks like:** No way to go from a user complaint ("my request failed at 2:15pm") to the system's view of that request. No request ID exposed to the user, no way to search by user ID + time.
+
+**Why it's bad:** Customer support tickets require manual log diving. Incident response starts with "which request?" instead of "what happened?".
+
+**SEEMS:** Misconfiguration (can't diagnose user-reported issues)
+**FaCTOR:** Fault isolation (can't connect user experience to system behaviour)
+**Typical severity:** MEDIUM / L1
+
+### OP-07: Averages instead of percentiles
+
+**What it looks like:** Latency measured as an average (mean) rather than as a histogram with percentile computation.
+
+**Why it's bad:** Averages hide tail latency. A service with 1ms average and 10-second P99 looks healthy by average but is terrible for 1% of users. SLOs based on averages are meaningless.
+
+**SEEMS:** Excessive latency (tail latency is invisible)
+**FaCTOR:** Timeliness (SLO measurement is misleading)
+**Typical severity:** MEDIUM / L2
+
+---
+
+## Availability Pillar Anti-Patterns
+
+### AP-01: Unbounded retry
+
+**What it looks like:** `while True: try ... except: retry` — retry loop with no maximum attempt count.
+
+**Why it's bad:** Under dependency failure, every in-flight request retries indefinitely. Load on the failing dependency increases instead of decreasing. Recovery becomes impossible because the retry traffic overwhelms the dependency the moment it tries to come back.
+
+**SEEMS:** Excessive load
+**FaCTOR:** Capacity (no bound on retry-generated load)
+**Typical severity:** HIGH / HYG (Total — can take down the service and prevent dependency recovery)
+
+### AP-02: Retry without backoff
+
+**What it looks like:** Retry with a fixed delay (e.g., `sleep(1)` between retries) or no delay at all.
+
+**Why it's bad:** All retries fire at the same interval, maintaining constant pressure on the failing dependency. No space for recovery.
+
+**SEEMS:** Excessive load
+**FaCTOR:** Capacity
+**Typical severity:** HIGH / L1 (escalates to HYG if unbounded)
+
+### AP-03: Retry without jitter
+
+**What it looks like:** Exponential backoff but all clients use the same delay schedule (e.g., 1s, 2s, 4s, 8s with no randomisation).
+
+**Why it's bad:** Thundering herd — all clients that failed at the same time retry at the same time, creating periodic spikes of load on the dependency.
+
+**SEEMS:** Excessive load
+**FaCTOR:** Capacity
+**Typical severity:** MEDIUM / L2
+
+### AP-04: Missing timeout on external call
+
+**What it looks like:** HTTP, database, cache, or queue client call with no explicit timeout.
+
+**Why it's bad:** A hung dependency blocks the calling thread indefinitely. Under failure, all worker threads can be consumed, making the service completely unresponsive.
+
+**SEEMS:** Excessive latency
+**FaCTOR:** Timeliness
+**Typical severity:** HIGH / HYG (Total — if in the request path)
+
+### AP-05: Timeout longer than user patience
+
+**What it looks like:** A 30-second or 60-second timeout on a call that's part of a user-facing request where users wait 3-5 seconds.
+
+**Why it's bad:** The timeout "protects" the service but the user has already given up and retried (or left). Resources are tied up serving a response nobody will receive.
+
+**SEEMS:** Excessive latency
+**FaCTOR:** Timeliness
+**Typical severity:** MEDIUM / L2
+
+### AP-06: Health check doesn't check dependencies
+
+**What it looks like:** Health check returns 200 if the process is running, without verifying database, cache, or other critical dependencies.
+
+**Why it's bad:** The service reports healthy but can't serve requests. Load balancers route traffic to it. Users get errors.
+
+**SEEMS:** Misconfiguration
+**FaCTOR:** Availability
+**Typical severity:** MEDIUM / L1
+
+### AP-07: Health check too sensitive (flapping)
+
+**What it looks like:** Health check fails on a single transient error (one failed DB query) without any dampening.
+
+**Why it's bad:** Transient errors cause the health check to flap between healthy and unhealthy. The orchestrator/load balancer keeps adding and removing the instance, causing instability.
+
+**SEEMS:** Single points of failure (availability depends on a single probe)
+**FaCTOR:** Availability
+**Typical severity:** MEDIUM / L2
+
+### AP-08: Synchronous call to non-critical service
+
+**What it looks like:** A user-facing request handler that makes a synchronous call to a non-critical service (analytics, recommendations, audit logging) in the request path.
+
+**Why it's bad:** If the non-critical service is slow or down, the critical user-facing request is degraded or fails. Non-critical work should not block critical paths.
+
+**SEEMS:** Shared fate (non-critical dependency failure cascades to critical path)
+**FaCTOR:** Fault isolation
+**Typical severity:** MEDIUM / L2
+
+### AP-09: No fallback when cache is unavailable
+
+**What it looks like:** Cache miss or cache failure causes the request to fail entirely, rather than falling back to the source of truth (database, API).
+
+**Why it's bad:** The cache was introduced to improve performance, but it became a hard dependency. Cache failure = service failure.
+
+**SEEMS:** Single points of failure (cache is a SPOF)
+**FaCTOR:** Redundancy
+**Typical severity:** MEDIUM / L2
+
+### AP-10: Circuit breaker that never closes
+
+**What it looks like:** Circuit breaker opens when a dependency fails but has no half-open state or recovery mechanism. Once open, it stays open permanently.
+
+**Why it's bad:** The circuit breaker correctly protects the service during failure but never allows recovery. The dependency recovers but the service never notices. Permanent degradation.
+
+**SEEMS:** Single points of failure (recovery path is broken)
+**FaCTOR:** Availability
+**Typical severity:** MEDIUM / L2
+
+---
+
+## Delivery Pillar Anti-Patterns
+
+### DP-01: Non-reversible database migration
+
+**What it looks like:** `DROP COLUMN`, `DROP TABLE`, data type narrowing, or `RENAME COLUMN` without a two-phase approach.
+
+**Why it's bad:** If the new code has a bug and needs rollback, the old code expects the dropped/renamed schema. Rollback requires a backup restore = downtime.
+
+**SEEMS:** Misconfiguration (deployment error causes data loss)
+**FaCTOR:** Output correctness (old and new versions can't coexist)
+**Typical severity:** HIGH / HYG (Irreversible — data/schema permanently changed)
+
+### DP-02: Breaking API change without versioning
+
+**What it looks like:** Removing or renaming a field in an API response. Changing the type of a field. Removing an endpoint.
+
+**Why it's bad:** Existing clients break. If the change is deployed gradually (canary/rolling), some clients hit old instances and some hit new ones — intermittent failures.
+
+**SEEMS:** Shared fate (deployment affects all consumers simultaneously)
+**FaCTOR:** Output correctness (inconsistent results during rollout)
+**Typical severity:** HIGH / L1
+
+### DP-03: Config change requires coordinated deployment
+
+**What it looks like:** A config value in Service A that must match a corresponding value in Service B. Updating one without the other causes failures.
+
+**Why it's bad:** Coordinated deployments are fragile. If one deploy succeeds and the other fails (or is delayed), the system is in an inconsistent state.
+
+**SEEMS:** Shared fate (services coupled through config)
+**FaCTOR:** Fault isolation (one service's deployment failure cascades)
+**Typical severity:** MEDIUM / L2
+
+### DP-04: Removing feature flag before stabilisation
+
+**What it looks like:** A feature flag is removed (code hardcoded to the new behaviour) before the feature has been running in production long enough to confirm stability.
+
+**Why it's bad:** If a latent bug surfaces after flag removal, the only remediation is a full code rollback. With the flag, the team could disable the feature in seconds.
+
+**SEEMS:** Misconfiguration (no way to disable the feature)
+**FaCTOR:** Availability (no kill switch)
+**Typical severity:** MEDIUM / L2
+
+### DP-05: Deployment requires downtime
+
+**What it looks like:** A change that requires stopping the old version before starting the new one (e.g., because they can't coexist, or because a migration requires exclusive access).
+
+**Why it's bad:** Every deployment is a planned outage. Deployment frequency is constrained by downtime windows. Hotfixes are delayed.
+
+**SEEMS:** Shared fate (deployment and availability are coupled)
+**FaCTOR:** Availability (service unavailable during deployment)
+**Typical severity:** MEDIUM / L3
+
+### DP-06: Missing health check for new functionality
+
+**What it looks like:** A new feature or endpoint is added but the health check is not updated to verify the new functionality's dependencies.
+
+**Why it's bad:** The health check says "healthy" even if the new feature's dependencies are down. Traffic is routed to an instance that can't serve the new feature.
+
+**SEEMS:** Misconfiguration (health check doesn't reflect true readiness)
+**FaCTOR:** Availability
+**Typical severity:** MEDIUM / L1
+
+### DP-07: Hardcoded values that should be configurable
+
+**What it looks like:** Timeout values, connection pool sizes, feature thresholds, or service URLs hardcoded in source code.
+
+**Why it's bad:** Changing these values requires a code change and deployment. In an incident, you can't adjust behaviour without a deploy.
+
+**SEEMS:** Misconfiguration (can't adjust without deploy)
+**FaCTOR:** Availability (can't respond to incidents with config changes)
+**Typical severity:** LOW / L1
+
+### DP-08: Secrets in code or config files
+
+**What it looks like:** API keys, passwords, tokens, or connection strings committed to source code or checked-in config files.
+
+**Why it's bad:** Secrets are exposed to anyone with repo access. They end up in CI logs, Docker images, and backups. Rotation requires a code change and deploy.
+
+**SEEMS:** Misconfiguration
+**FaCTOR:** Fault isolation (compromised secret affects everything that uses it)
+**Typical severity:** HIGH / HYG (Irreversible — once committed, the secret is in git history forever)
+
+### DP-09: Dependencies on deployment order
+
+**What it looks like:** Service A must be deployed before Service B, or Database migration must run before Service C starts.
+
+**Why it's bad:** Deployment ordering is fragile and poorly communicated. If the order is violated (by automation, by a new team member, by parallel deploys), the system breaks.
+
+**SEEMS:** Shared fate (services coupled through deployment order)
+**FaCTOR:** Fault isolation (one deployment's timing affects others)
+**Typical severity:** MEDIUM / L2
+
+---
+
+## Adding New Anti-Patterns
+
+When adding a new anti-pattern to this catalogue or to the prompts:
+
+1. Give it a **short, memorable name** (not "Bad Practice #7")
+2. Describe **what it looks like** in code (concrete, not abstract)
+3. Explain **why it's bad** in terms of production impact
+4. Classify with **SEEMS category** and **FaCTOR property**
+5. Assign a **typical severity** with reasoning
+6. Note **boundary conditions** that would change the severity

--- a/spec/sre/calibration.md
+++ b/spec/sre/calibration.md
@@ -1,0 +1,259 @@
+# Calibration Examples — SRE Domain
+
+> Worked examples showing how to judge severity and maturity level for real code patterns. Use these to calibrate prompt output and verify consistency across reviews.
+
+## How to use this document
+
+Each example shows:
+1. **Code pattern** — what the reviewer sees
+2. **Assessment** — severity, maturity level, SEEMS/FaCTOR category
+3. **Reasoning** — why this severity and level, not higher or lower
+4. **Boundary note** — what would change the assessment up or down
+
+---
+
+## Response Pillar
+
+### Example R1: Generic error message (MEDIUM / L1)
+
+**Code pattern:**
+```python
+except Exception as e:
+    logger.error("Failed to process request")
+    return {"error": "An error occurred"}, 500
+```
+
+**Assessment:** MEDIUM | L1 | Fault isolation
+
+**Reasoning:** The error message is generic — an operator cannot distinguish a database failure from a config error from a code bug. However, the error IS logged (not swallowed), and the service returns a 500 (not a 200). The caller knows something failed. This is a L1 gap (errors don't propagate with sufficient context) but not Hygiene because the failure is visible, not masked.
+
+**Boundary — would be HIGH / HYG if:**
+```python
+except Exception:
+    return {"status": "ok"}, 200  # Swallows error, returns success
+```
+This masks data loss (irreversible) — the caller believes the operation succeeded.
+
+**Boundary — would be LOW / L2 if:**
+```python
+except Exception as e:
+    logger.error("Failed to process request", extra={"error": str(e), "request_id": req_id})
+    return {"error": "Internal server error", "request_id": req_id}, 500
+```
+Context exists for diagnosis but there's no error categorisation (retryable vs permanent) — that's an L2 concern.
+
+### Example R2: Swallowed exception (HIGH / HYG)
+
+**Code pattern:**
+```python
+try:
+    await publish_event(order_completed)
+except Exception:
+    pass  # Don't let event publishing block the order flow
+```
+
+**Assessment:** HIGH | HYG | Fault isolation (Irreversible test: yes)
+
+**Reasoning:** The event is silently dropped. Downstream consumers (billing, analytics, notifications) will never receive it. There is no dead letter queue, no retry, no log. The data loss is irreversible — the event is gone and nobody knows it's missing.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+except Exception as e:
+    logger.warning("Failed to publish order event, will retry", extra={"order_id": order.id, "error": str(e)})
+    await retry_queue.enqueue(order_completed)
+```
+The failure is logged, retried, and recoverable. Now it's an L1 concern about whether the retry mechanism is robust enough.
+
+### Example R3: Stack trace in API response (MEDIUM / L1)
+
+**Code pattern:**
+```python
+except Exception as e:
+    return {"error": traceback.format_exc()}, 500
+```
+
+**Assessment:** MEDIUM | L1 | Output correctness
+
+**Reasoning:** Stack traces expose internal implementation details to callers. This is an L1 gap (error responses aren't well-formed). Not HIGH because it's an information disclosure issue more than an operational reliability issue — the service still correctly signals failure.
+
+**Boundary — would be HIGH / HYG if:** The stack trace contains database connection strings, credentials, or PII (Regulated test: yes).
+
+---
+
+## Observability Pillar
+
+### Example O1: Print statements instead of logging (MEDIUM / L1)
+
+**Code pattern:**
+```python
+def process_order(order):
+    print(f"Processing order {order.id}")
+    result = payment_service.charge(order.total)
+    print(f"Payment result: {result}")
+```
+
+**Assessment:** MEDIUM | L1 | Observability (missing structured logging)
+
+**Reasoning:** `print()` produces unstructured output with no log level, no timestamp (beyond terminal), no correlation ID, and no way to filter by severity. This is a clear L1 gap. MEDIUM because the information IS emitted (not silent), but it's unusable for production diagnosis.
+
+**Boundary — would be HIGH / L1 if:** The `print()` is in a catch block and it's the only signal of a failure — meaning critical errors are invisible to alerting systems.
+
+**Boundary — would be LOW / L2 if:** Structured logging exists but some non-critical debug paths still use `print()`.
+
+### Example O2: Unbounded metric cardinality (HIGH / L2)
+
+**Code pattern:**
+```python
+metrics.histogram(
+    "request_duration",
+    duration,
+    labels={"endpoint": path, "user_id": user.id}
+)
+```
+
+**Assessment:** HIGH | L2 | Capacity
+
+**Reasoning:** Using `user_id` as a metric label creates unbounded cardinality — one time series per user. This will eventually exhaust the metrics backend's memory/storage and crash the monitoring system. This is HIGH because it can cause a cascading failure in the observability infrastructure itself.
+
+**Boundary — Hygiene (Total) if:** The metrics backend is shared across services and unbounded cardinality from this service can take down monitoring for all services.
+
+**Boundary — MEDIUM / L2 if:** The label is something like `customer_tier` (a small, bounded set of values) that just needs documentation.
+
+### Example O3: No SLI metrics emitted (MEDIUM / L2)
+
+**Code pattern:** A request handler that processes HTTP requests but emits no latency histogram, no error counter, and no throughput metric.
+
+**Assessment:** MEDIUM | L2 | Timeliness
+
+**Reasoning:** Without SLI metrics, the team cannot define or measure SLOs. They cannot set alerts on latency percentiles or error rates. This is an L2 gap (SLOs not measurable from telemetry). MEDIUM because the service may still have logs that provide some visibility, but quantitative SLO tracking is impossible.
+
+---
+
+## Availability Pillar
+
+### Example A1: Unbounded retry with no backoff (HIGH / HYG)
+
+**Code pattern:**
+```python
+def call_payment_service(order):
+    while True:
+        try:
+            return payment_api.charge(order)
+        except Exception:
+            time.sleep(1)  # Fixed 1-second delay, no backoff, no bound
+```
+
+**Assessment:** HIGH | HYG | Excessive load (Total test: yes)
+
+**Reasoning:** Under dependency failure, this retries forever at a fixed 1-second interval. If 1000 requests are in flight when the payment service goes down, they all retry every second indefinitely — generating 1000 req/s of retry traffic on top of new incoming requests. This is a retry storm that can exhaust threads, connections, and overwhelm the dependency when it tries to recover. Total: can take down the service and prevent the dependency from recovering.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+for attempt in range(3):
+    try:
+        return payment_api.charge(order)
+    except Exception:
+        time.sleep(2 ** attempt)  # Bounded retries with exponential backoff
+raise PaymentServiceUnavailable(order.id)
+```
+Bounded retries with backoff. Still missing jitter (thundering herd risk), which is an L1 concern.
+
+### Example A2: Missing timeout on HTTP call (HIGH / HYG)
+
+**Code pattern:**
+```python
+response = requests.post(url, json=payload)
+```
+
+**Assessment:** HIGH | HYG | Excessive latency (Total test: yes)
+
+**Reasoning:** No timeout parameter. If the remote service hangs (accepts the connection but never responds), this call blocks the thread indefinitely. In a request-handling context, this blocks one worker thread per stuck request. Under dependency failure, all worker threads can be consumed, making the service completely unresponsive. Total: can render the entire service unresponsive.
+
+**Boundary — would be MEDIUM / L1 if:** The call is in a background job with its own thread pool that cannot starve the request-handling path. Still a timeout gap (L1) but not service-fatal.
+
+### Example A3: Health check always returns healthy (HIGH / HYG)
+
+**Code pattern:**
+```python
+@app.route("/health")
+def health():
+    return {"status": "healthy"}, 200
+```
+
+**Assessment:** HIGH | HYG | Availability (Total test: yes)
+
+**Reasoning:** This health check always returns healthy regardless of actual service state. If the database is down, if the service is out of memory, if a critical dependency is unreachable — the health check still says "healthy". Load balancers and orchestrators will continue routing traffic to a broken instance. Total: routes all traffic into a black hole.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+@app.route("/health")
+def health():
+    try:
+        db.execute("SELECT 1")
+        return {"status": "healthy"}, 200
+    except Exception:
+        return {"status": "unhealthy"}, 503
+```
+Checks one dependency but doesn't check others (cache, queue). L1 gap — health check is real but incomplete.
+
+---
+
+## Delivery Pillar
+
+### Example D1: Irreversible database migration (HIGH / HYG)
+
+**Code pattern:**
+```sql
+ALTER TABLE users DROP COLUMN legacy_email;
+ALTER TABLE users RENAME COLUMN new_email TO email;
+```
+
+**Assessment:** HIGH | HYG | Output correctness (Irreversible test: yes)
+
+**Reasoning:** This migration drops data (`legacy_email` column) and renames a column. If the new code has a bug and needs to be rolled back, the old code expects `legacy_email` to exist — but it's gone. The data is permanently lost. Rollback is impossible without a backup restore, which means downtime.
+
+**Boundary — would be MEDIUM / L1 if:**
+```sql
+-- Step 1 (this deploy): Add new column, backfill
+ALTER TABLE users ADD COLUMN email_v2 VARCHAR(255);
+UPDATE users SET email_v2 = COALESCE(new_email, legacy_email);
+
+-- Step 2 (next deploy, after verification): Remove old columns
+```
+Two-phase migration: add-before-remove. The first step is reversible.
+
+### Example D2: Feature deployed without flag (MEDIUM / L2)
+
+**Code pattern:** A new payment processing flow that replaces the old one, deployed directly without a feature flag.
+
+**Assessment:** MEDIUM | L2 | Availability
+
+**Reasoning:** If the new flow has a bug, the only remediation is a full rollback of the deployment. With a feature flag, the team could disable the new flow instantly (seconds) without a deploy (minutes to hours). This is an L2 concern — the feature works, but there's no operational control over it.
+
+**Boundary — would be HIGH / HYG if:** The new flow changes data formats in a way that the old flow can't read, making rollback destructive (Irreversible).
+
+### Example D3: Config requires coordinated deployment (MEDIUM / L2)
+
+**Code pattern:** Service A reads a config value that must match a corresponding config in Service B. Updating one without the other causes failures.
+
+**Assessment:** MEDIUM | L2 | Shared fate
+
+**Reasoning:** Coordinated deployments are fragile — if one service deploys and the other doesn't (due to a failed deploy, a queue, or human error), the services are in an inconsistent state. This is an L2 concern about shared fate between services.
+
+**Boundary — would be HIGH / HYG if:** The inconsistent state causes data corruption (Irreversible) or cascading failure (Total).
+
+---
+
+## Cross-pillar: How the same issue gets different assessments
+
+### Missing timeout — assessed by different pillars
+
+The same `requests.post(url, json=payload)` (no timeout) might be flagged by:
+
+| Pillar | Category | Emphasis |
+|--------|----------|----------|
+| **Response** | Excessive latency | "Timeouts are not reported with context about what was being waited on" |
+| **Observability** | Timeliness | "Cannot measure latency against SLO targets for this call" |
+| **Availability** | Excessive latency | "Thread blocked indefinitely, can exhaust worker pool" (this is the HYG finding) |
+
+**During synthesis:** These merge into one finding. The Availability pillar's assessment (HYG / Total) takes precedence as the highest severity. The recommendation combines: "Add explicit timeout (availability), log the timeout with dependency context (response), emit a latency metric for this call (observability)."

--- a/spec/sre/framework-map.md
+++ b/spec/sre/framework-map.md
@@ -1,0 +1,130 @@
+# Framework Map — SEEMS, FaCTOR, and ROAD
+
+> How the three SRE frameworks relate to each other. Use this map when writing or reviewing prompts to ensure coverage is complete and lenses are applied correctly.
+
+## The Duality: SEEMS attacks, FaCTOR defends
+
+Every SEEMS failure mode has one or more FaCTOR properties that mitigate it. When a reviewer identifies a SEEMS problem, they should recommend strengthening the corresponding FaCTOR property.
+
+| SEEMS failure mode | Primary FaCTOR defence | Secondary FaCTOR defence | Why this pairing |
+|--------------------|----------------------|------------------------|-----------------|
+| **Shared fate** | **Fault isolation** | Redundancy | Shared fate creates coupling; fault isolation (bulkheads) breaks coupling; redundancy ensures one path remains. |
+| **Excessive load** | **Capacity** | Fault isolation | Excessive load overwhelms resources; capacity controls (load shedding, backpressure) bound the damage; fault isolation prevents spillover. |
+| **Excessive latency** | **Timeliness** | Availability | Excessive latency breaches SLOs; timeliness (timeouts, bounded operations) caps the damage; availability (graceful degradation) serves partial results. |
+| **Misconfiguration** | **Output correctness** | Fault isolation | Misconfig produces wrong behaviour; output correctness (validation, fail-safe defaults) catches it; fault isolation limits the blast radius. |
+| **Single points of failure** | **Redundancy** | Availability | SPOFs mean one failure = total loss; redundancy provides failover; availability ensures degraded-but-running over down. |
+
+### Using the duality in reviews
+
+When writing a finding:
+1. Identify the **SEEMS category** (how the code fails)
+2. Check the **FaCTOR defence** (what should protect against it)
+3. If the defence is missing or insufficient, that's the finding
+4. The recommendation should describe the FaCTOR property to strengthen, not a specific technique
+
+Example:
+- SEEMS: Excessive load (retry without backoff on line 47)
+- FaCTOR defence needed: Capacity (bounded retries with backoff)
+- Finding: "Unbounded retry on dependency failure can amplify load under stress"
+- Recommendation: "Bound retry count and add exponential backoff with jitter to prevent load amplification"
+
+## ROAD Pillar Focus Areas
+
+Each ROAD pillar emphasises specific SEEMS/FaCTOR elements. This is not exclusive — any pillar can flag any category — but these are the primary focus areas that each subagent should prioritise.
+
+### Response pillar
+
+**Mandate:** Can operators diagnose and recover from failures?
+
+| SEEMS focus | Why |
+|-------------|-----|
+| Misconfiguration | Config errors are the #1 cause of operator confusion during incidents. If the error message doesn't distinguish "wrong config" from "dependency down", MTTR increases. |
+| Shared fate | When a shared dependency fails, operators need to know *which* dependency and *why*. Ambiguous failure attribution extends incidents. |
+| Excessive latency | Timeout errors need context about what was being waited on and how long. "Request timed out" without details is useless at 3am. |
+
+| FaCTOR focus | Why |
+|--------------|-----|
+| Fault isolation | Failures must be attributed to the correct component. If errors propagate without source attribution, operators chase the wrong service. |
+| Output correctness | Error responses must be well-formed and follow API contracts. Malformed errors break client error handling and confuse automated alerting. |
+
+### Observability pillar
+
+**Mandate:** Can we see what the system is doing in production?
+
+| SEEMS focus | Why |
+|-------------|-----|
+| Excessive load | If load isn't visible (request rates, queue depths), operators can't see overload developing until it's too late. |
+| Excessive latency | If latency percentiles aren't captured, slow dependencies are invisible until they breach SLOs. |
+| Misconfiguration | If config values aren't logged at startup or exposed as metrics, config-related failures are impossible to diagnose without code access. |
+
+| FaCTOR focus | Why |
+|--------------|-----|
+| Capacity | Resource utilisation (connection pools, memory, CPU) must be visible to detect saturation before it causes failure. |
+| Timeliness | Latency must be measurable against SLO targets. If you can't measure it, you can't alert on it. |
+
+### Availability pillar
+
+**Mandate:** Does the system meet SLOs and degrade gracefully?
+
+This pillar has the broadest SEEMS/FaCTOR coverage because availability is the aggregate outcome of all resilience properties.
+
+| SEEMS focus | Why |
+|-------------|-----|
+| Shared fate | Blast radius analysis. If this fails, what else fails? |
+| Excessive load | What happens at 10x traffic? Retry storms? Fan-out amplification? |
+| Excessive latency | Worst-case latency? Unbounded operations? |
+| Single points of failure | Redundancy story? Failover paths? |
+
+| FaCTOR focus | Why |
+|--------------|-----|
+| Fault isolation | Bulkheads between tenants, request types, dependencies. |
+| Availability | Degraded mode design. Is "something" better than "nothing"? |
+| Capacity | Limits defined? Load shedding? Admission control? |
+| Redundancy | Failover path? Recovery time? Data loss during failover? |
+
+### Delivery pillar
+
+**Mandate:** Can we ship and roll back safely?
+
+| SEEMS focus | Why |
+|-------------|-----|
+| Misconfiguration | A config change during deployment can cause outage. Safe defaults and validation matter most during rollout. |
+| Shared fate | Coordinated multi-service deployments create shared fate. One service's deployment failure shouldn't block others. |
+
+| FaCTOR focus | Why |
+|--------------|-----|
+| Output correctness | During rollout, old and new versions coexist. Both must produce consistent results or users see inconsistent behaviour. |
+| Availability | Deployment must not cause downtime. Rollback must not cause data loss. |
+
+## Coverage Matrix
+
+This matrix shows which SEEMS/FaCTOR combinations are covered by which ROAD pillar. Use it to verify that prompt changes don't create coverage gaps.
+
+| | Shared fate | Excessive load | Excessive latency | Misconfiguration | SPOF |
+|---|---|---|---|---|---|
+| **Response** | Primary | - | Secondary | Primary | - |
+| **Observability** | - | Primary | Primary | Secondary | - |
+| **Availability** | Primary | Primary | Primary | - | Primary |
+| **Delivery** | Secondary | - | - | Primary | - |
+
+| | Fault isolation | Availability | Capacity | Timeliness | Output correctness | Redundancy |
+|---|---|---|---|---|---|---|
+| **Response** | Primary | - | - | - | Primary | - |
+| **Observability** | - | - | Primary | Primary | - | - |
+| **Availability** | Primary | Primary | Primary | - | - | Primary |
+| **Delivery** | - | Secondary | - | - | Primary | - |
+
+**Key:** Primary = core focus area for this pillar. Secondary = reviewed but not the primary lens. `-` = not a focus area (may still be flagged if found).
+
+## Inter-pillar Handoffs
+
+When a finding spans pillars, the subagent that discovers it should flag it in their own pillar's terms. The synthesis step deduplicates across pillars.
+
+Common handoff scenarios:
+
+| Scenario | Discovered by | Also relevant to |
+|----------|---------------|------------------|
+| Missing timeout causes both unobservable latency and availability risk | Observability or Availability | Both — deduplicate during synthesis |
+| Error message quality affects both incident response and observability | Response | Observability (if the error doesn't emit a metric/log) |
+| Database migration affects both deployment safety and availability | Delivery | Availability (if migration causes downtime) |
+| Health check quality affects both response (diagnosability) and availability (traffic routing) | Availability | Response |

--- a/spec/sre/glossary.md
+++ b/spec/sre/glossary.md
@@ -1,0 +1,112 @@
+# Glossary — SRE Domain
+
+> Canonical definitions for all terms, frameworks, and acronyms used in the SRE review domain. When writing or modifying prompts, use these definitions exactly.
+
+## Frameworks
+
+### ROAD
+
+**Response, Observability, Availability, Delivery.** The structural framework that organises the SRE review into four pillars, each with a dedicated subagent.
+
+Origin: Bruce Dominguez.
+
+| Pillar | One-line mandate |
+|--------|-----------------|
+| **R**esponse | Can operators diagnose and recover from failures? |
+| **O**bservability | Can we see what the system is doing in production? |
+| **A**vailability | Does the system meet SLOs and degrade gracefully? |
+| **D**elivery | Can we ship and roll back safely? |
+
+### SEEMS
+
+**Shared fate, Excessive load, Excessive latency, Misconfiguration, Single points of failure.** Five categories of failure modes. SEEMS is the "offensive" lens — it asks *"How will this code fail in production?"*
+
+| Category | Definition | Recognition heuristic |
+|----------|-----------|----------------------|
+| **S**hared fate | Component coupling that causes correlated failures across otherwise-independent consumers. | Look for: shared DB, shared cache, shared queue, shared connection pool, shared thread pool serving multiple consumers. |
+| **E**xcessive load | Patterns that amplify load under stress, turning a partial failure into a total one. | Look for: retry without backoff, fan-out without backpressure, unbounded parallelism, missing rate limits, no admission control. |
+| **E**xcessive latency | Operations with unbounded execution time that block resources and breach SLOs. | Look for: missing timeouts on external calls, synchronous call chains, head-of-line blocking, full table scans, unbounded pagination. |
+| **M**isconfiguration | Configuration errors that cause outages, especially those that are hard to diagnose. | Look for: hardcoded values that should be configurable, no startup validation, no fail-safe defaults, magic strings without documentation. |
+| **S**ingle points of failure | Components with no redundancy whose failure causes total loss of function. | Look for: single-instance services, non-replicated state, no failover path, no fallback, unique hardware dependency. |
+
+**Compounding rule:** SEEMS categories compound. Excessive load + Shared fate = cascading retry storms. Misconfiguration + Single point of failure = one typo takes down the only instance. Prompts should note when categories interact.
+
+### FaCTOR
+
+**Fault isolation, Availability, Capacity, Timeliness, Output correctness, Redundancy.** Six resilience properties that code should preserve. FaCTOR is the "defensive" lens — it asks *"What protects this code from failing in production?"*
+
+| Property | What "good" looks like | What "bad" looks like |
+|----------|----------------------|---------------------|
+| **F**ault isolation | Failures stay within their boundary. Bulkheads exist between components. Error handling prevents cascade. | One component failure propagates through the system. Shared resources become a single point of coupling. |
+| **A**vailability | System degrades gracefully. Partial functionality is preferred over total failure. Health checks reflect real readiness. | Binary mode: either fully working or completely down. Health checks are hardcoded or trivial. |
+| **C**apacity | Load shedding exists. Backpressure mechanisms work. Resource limits are defined. Queue depths are bounded. | Unbounded work acceptance. No backpressure. Resources exhausted under load. |
+| **T**imeliness | Operations have bounded latency. Timeouts are set appropriately. SLOs can be met under load. | P99 latency grows unbounded under stress. No timeouts. SLOs breached during normal peaks. |
+| **O**utput correctness | Idempotent where needed. Delivery semantics (exactly-once, at-least-once) are explicit. Data consistency is maintained during failures. | Silent data corruption. Duplicate processing. Inconsistent state after partial failures. |
+| **R**edundancy | No new single points of failure. Failover paths exist. State can be recovered after failure. | Single-instance critical paths. No failover. Unrecoverable state after restart. |
+
+### SEEMS-FaCTOR Duality
+
+Every SEEMS failure mode has a corresponding FaCTOR property that mitigates it. See `framework-map.md` for the complete mapping.
+
+## Maturity Model
+
+### Hygiene Gate
+
+A promotion gate that overrides maturity levels. Any finding at any level is promoted to `HYG` if it passes any of these three consequence-severity tests:
+
+| Test | Question | SRE examples |
+|------|----------|--------------|
+| **Irreversible** | If this goes wrong, can the damage be undone? | Catch-all exception handler that returns success, masking data loss. Silent data corruption with no audit trail. |
+| **Total** | Can this take down the entire service or cascade beyond its boundary? | Retry loop with no bound or backoff that can exhaust thread pools. Health check hardcoded to return healthy, routing traffic to dead instances. Missing timeout on external call that blocks the only worker thread. |
+| **Regulated** | Does this violate a legal or compliance obligation? | PII logged to stdout without masking. Health data exposed in error responses. |
+
+Any "yes" to any test = `HYG`. The Hygiene flag trumps all maturity levels.
+
+### Maturity Levels
+
+Levels are cumulative. Each requires the previous. See `maturity-criteria.md` for detailed criteria with thresholds.
+
+| Level | Name | One-line description |
+|-------|------|---------------------|
+| **L1** | Foundations | The basics are in place. The system can be operated. |
+| **L2** | Hardening | Production-ready practices. The system can be operated *well*. |
+| **L3** | Excellence | Best-in-class. The system is a model for others. |
+
+### Severity Levels
+
+| Level | Production impact | Merge decision |
+|-------|------------------|----------------|
+| **HIGH** | Could cause outage, data loss, or significant degradation | Must fix before merge |
+| **MEDIUM** | Operational risk that should be addressed | May require follow-up ticket |
+| **LOW** | Minor improvement opportunity | Nice to have |
+
+Severity measures **production consequence**, not implementation difficulty.
+
+### Status Indicators
+
+Used in maturity assessment tables:
+
+| Indicator | Meaning |
+|-----------|---------|
+| `pass` | All criteria at this level are met |
+| `partial` | Some criteria met, some not |
+| `fail` | No criteria met, or critical criteria missing |
+| `locked` | Previous level not achieved; this level cannot be assessed |
+
+## Orchestration Terms
+
+| Term | Definition |
+|------|-----------|
+| **Pillar** | One of the 4 ROAD components (Response, Observability, Availability, Delivery). Each pillar has one subagent. |
+| **Subagent** | A specialised reviewer that analyses code against one pillar's checklist. Runs in parallel with the other 3. |
+| **Skill orchestrator** | The `/review-sre` skill that dispatches subagents, collects results, deduplicates, and synthesises the final report. |
+| **Synthesis** | The process of merging 4 subagent reports into one consolidated maturity assessment. |
+| **Deduplication** | When two subagents flag the same file:line, merging into one finding with the highest severity and most restrictive maturity tag. |
+
+## Output Terms
+
+| Term | Definition |
+|------|-----------|
+| **Finding** | A single identified issue: severity, maturity level, SEEMS/FaCTOR category, file location, description, and recommendation. |
+| **Maturity assessment** | Per-criterion evaluation (met/not met/partially met) for each maturity level. |
+| **Immediate action** | The single most important thing to fix. Hygiene failure if any exist, otherwise the top finding from the next achievable level. |

--- a/spec/sre/maturity-criteria.md
+++ b/spec/sre/maturity-criteria.md
@@ -1,0 +1,299 @@
+# Maturity Criteria — SRE Domain
+
+> Detailed criteria for each maturity level with defined "sufficient" thresholds. Use this when assessing criteria as Met / Not met / Partially met.
+
+## Hygiene Gate
+
+The Hygiene gate is not a maturity level — it is a promotion gate. Any finding at any level that passes any of the three tests is promoted to `HYG`.
+
+### Test 1: Irreversible
+
+**Question:** If this goes wrong, can the damage be undone?
+
+**Threshold:** If a failure would produce damage that requires more than a rollback/restart to fix — e.g., corrupted data that has been served to users, leaked credentials that must be rotated, lost records with no backup — this is irreversible.
+
+**SRE examples that trigger this test:**
+- Catch-all exception handler that swallows errors and returns success, masking data loss to upstream consumers
+- Write path with no idempotency that can produce duplicate records on retry
+- Background job that deletes records before confirming downstream receipt
+- Error handler that logs to a buffer with no flush guarantee — logs lost on crash
+
+**SRE examples that do NOT trigger this test:**
+- Missing retry logic (service returns an error, but the error is visible and the user can retry)
+- Suboptimal timeout value (causes degraded experience, but no lasting damage)
+
+### Test 2: Total
+
+**Question:** Can this take down the entire service or cascade beyond its boundary?
+
+**Threshold:** If a failure can exhaust a shared resource (threads, connections, memory, CPU) to the point where the entire service becomes unresponsive, or if the failure propagates to other services beyond its boundary, this is total.
+
+**SRE examples that trigger this test:**
+- Retry loop with no bound and no backoff — under dependency failure, retries consume all threads/connections
+- Health check hardcoded to return healthy — load balancer routes traffic to a dead instance, all requests to that instance fail
+- Synchronous call to an external service with no timeout in the request path — one slow dependency blocks all request processing
+- Unbounded queue that grows under load until memory is exhausted
+- Connection pool shared between critical and non-critical paths — non-critical traffic can starve critical requests
+
+**SRE examples that do NOT trigger this test:**
+- A single endpoint returns a 500 error (contained failure, other endpoints still work)
+- A background job fails and stops processing (localised impact, not service-wide)
+
+### Test 3: Regulated
+
+**Question:** Does this violate a legal or compliance obligation?
+
+**Threshold:** If the code would cause a breach of data protection law, financial regulation, accessibility requirements, or other legal obligations, this is regulated.
+
+**SRE examples that trigger this test:**
+- PII (emails, phone numbers, health data) logged to stdout without masking
+- Error responses that include internal user data (names, addresses) in the response body
+- Health/medical data stored without encryption at rest
+
+**SRE examples that do NOT trigger this test:**
+- Internal service-to-service request IDs in logs (not PII)
+- Internal IP addresses in error messages (not regulated data in most contexts)
+
+---
+
+## Level 1 — Foundations
+
+**Overall intent:** The basics are in place. The system can be operated. An on-call engineer has enough information to respond to incidents.
+
+### Criterion 1.1: Health checks reflect real readiness
+
+**Definition:** Liveness and readiness probes test actual service functionality, not just process existence.
+
+**Met (sufficient):**
+- Health check endpoint exists
+- It verifies at least one critical dependency (database connectivity, cache reachability, or equivalent)
+- It returns unhealthy when the service cannot serve requests
+- It distinguishes between liveness (process is running) and readiness (can accept traffic)
+
+**Partially met:**
+- Health check exists but only checks process liveness (returns 200 if the process is running)
+- Health check exists but doesn't verify any dependencies
+
+**Not met:**
+- No health check endpoint
+- Health check hardcoded to return 200 / "OK"
+- Health check exists but is never called (not wired into infrastructure)
+
+### Criterion 1.2: Errors propagate with context sufficient for diagnosis
+
+**Definition:** When an error occurs, enough information is captured for an operator to understand what happened without reading the source code.
+
+**Met (sufficient) — minimum context:**
+- **What** failed: error type or category (not just a generic message)
+- **Where** it failed: service name + operation/endpoint
+- **Correlation**: request ID or trace ID that connects the error to the originating request
+- **Classification**: whether the error is retryable or permanent (via status code, error type, or explicit field)
+
+**Partially met:**
+- Some errors have good context, others are generic ("An error occurred")
+- Correlation IDs exist but are not propagated across async boundaries or service calls
+- Error types are distinguishable but missing request correlation
+
+**Not met:**
+- Generic catch blocks that log "error occurred" with no context
+- Exceptions swallowed silently (catch with no logging)
+- Stack traces are the only error information (requires code reading to interpret)
+- No correlation IDs anywhere in the codebase
+
+### Criterion 1.3: External calls have explicit timeouts
+
+**Definition:** Every call to an external dependency (HTTP, database, cache, queue, filesystem, third-party API) has an explicit timeout configured.
+
+**Met (sufficient):**
+- All external calls have timeouts
+- Timeout values are appropriate for the operation (not just a copy-pasted default)
+- Connect timeout and read timeout are distinguished where the client supports it
+- Timeout values are documented or self-evident from context
+
+**Partially met:**
+- Some external calls have timeouts, others rely on library/framework defaults
+- Timeouts exist but values are inappropriate (e.g., 5-minute timeout on a user-facing API call)
+
+**Not met:**
+- Any external call with no explicit timeout
+- Reliance on "the library has a default" without knowing what that default is
+
+### Criterion 1.4: Logging is structured with request correlation
+
+**Definition:** Log output uses structured format (JSON or key-value pairs) and includes correlation identifiers that connect log entries to specific requests.
+
+**Met (sufficient):**
+- Structured logging format (JSON, key-value, or equivalent — not string interpolation with `f"message {var}"`)
+- Log levels used correctly: ERROR for errors, WARN for recoverable issues, INFO for significant operations, DEBUG for details
+- Request/trace ID included in log entries for request-scoped operations
+- PII is not present in log output (or is explicitly masked)
+
+**Partially met:**
+- Structured format used but no correlation IDs
+- Correlation IDs present but logging format is unstructured (plain text with interpolated values)
+- Most logging is structured but some paths use `print()` or `console.log()`
+
+**Not met:**
+- All logging is `print()` / `console.log()` / unstructured
+- No correlation IDs
+- PII logged without masking
+
+---
+
+## Level 2 — Hardening
+
+**Overall intent:** Production-ready practices. The system can be operated *well*. Teams can set and track reliability targets.
+
+**Prerequisite:** All L1 criteria must be met.
+
+### Criterion 2.1: Service-level objectives are defined and measurable from telemetry
+
+**Definition:** The codebase emits signals (metrics, logs, or traces) that can be used to compute SLIs and track them against defined SLO targets.
+
+**Met (sufficient):**
+- SLI-relevant metrics are emitted: request latency (as histogram, not average), error rate (by type), throughput
+- Metrics can be used to compute SLOs (e.g., "99th percentile latency < 500ms", "error rate < 0.1%")
+- Metrics are labelled to distinguish SLO-relevant paths from SLO-exempt paths (health checks, admin endpoints)
+- Metric cardinality is bounded (no unbounded label values like user_id)
+
+**Partially met:**
+- Some SLI metrics exist but not all (e.g., latency but no error rate by type)
+- Metrics exist but use averages instead of percentiles for latency
+- Metrics exist but cardinality is unbounded
+
+**Not met:**
+- No SLI-relevant metrics emitted
+- Only business metrics, no request-level SLI metrics
+- Latency measured only as averages
+
+### Criterion 2.2: External dependencies have failure isolation
+
+**Definition:** When an external dependency fails, the failure does not propagate unchecked through the system. Some form of isolation exists.
+
+**Met (sufficient):**
+- Dependency failures are detected (timeout, error response, connection refused)
+- Failure is contained: the calling code handles the failure without crashing or blocking
+- There is some form of isolation: separate connection pools per dependency, circuit breaker patterns, bulkhead thread pools, or equivalent
+- Failure of a non-critical dependency does not affect the critical path
+
+**Partially met:**
+- Failures are handled (no crash) but there's no isolation between dependencies (shared connection pool, shared thread pool)
+- Circuit breaker or equivalent exists for some dependencies but not all external ones
+
+**Not met:**
+- Dependency failure causes the service to crash or hang
+- All dependencies share a single connection pool or thread pool
+- No distinction between critical and non-critical dependency failures
+
+### Criterion 2.3: Degradation paths exist
+
+**Definition:** The system can provide reduced functionality when a dependency is unavailable, rather than failing entirely.
+
+**Met (sufficient):**
+- At least one degradation path exists for non-critical dependencies (cached data, default values, reduced feature set)
+- The degradation is intentional and documented (not accidental)
+- The system communicates its degraded state (via metrics, logs, or health check status)
+
+**Partially met:**
+- Degradation exists for some paths but the service fails totally for others that could be degraded
+- Degradation exists but the system doesn't communicate its degraded state
+
+**Not met:**
+- No degradation paths — any dependency failure causes total failure
+- Degradation exists only by accident (e.g., empty catch blocks that return null)
+
+### Criterion 2.4: Alert definitions reference response procedures
+
+**Definition:** Alerting signals in the code are accompanied by context that helps operators respond.
+
+**Met (sufficient):**
+- Critical failure paths emit a signal (metric or log) that could be used as an alert trigger
+- Error messages or metric names are specific enough to identify the failure type (not just "error_count" but "dependency_timeout_count" or equivalent)
+- Alert-worthy signals distinguish between symptoms and causes
+
+**Partially met:**
+- Some alert-worthy signals exist but they're too generic to be actionable
+- Critical paths emit signals but there's no way to distinguish failure types from the signal alone
+
+**Not met:**
+- Critical failure paths don't emit any signal that could be alerted on
+- All errors produce the same metric/log — no way to distinguish failure types
+
+---
+
+## Level 3 — Excellence
+
+**Overall intent:** Best-in-class. The system is a model for others. Reliability is a first-class engineering discipline.
+
+**Prerequisite:** All L2 criteria must be met.
+
+### Criterion 3.1: Deployment can proceed without downtime
+
+**Definition:** The deployment strategy supports zero-downtime releases.
+
+**Met (sufficient):**
+- Code changes are backward compatible with the previous version
+- Database migrations (if any) are backward compatible (add-before-remove pattern)
+- Old and new versions can coexist during rollout
+- Rollback is possible without data loss
+
+**Partially met:**
+- Most changes are backward compatible but some require coordinated deployment
+- Rollback is possible but with some data loss or manual intervention
+
+**Not met:**
+- Deployment requires downtime
+- Database migrations are irreversible
+- Breaking changes deployed without feature flags or versioning
+
+### Criterion 3.2: Capacity limits are enforced under load
+
+**Definition:** The system actively protects itself when load exceeds capacity.
+
+**Met (sufficient):**
+- Request admission control exists (reject requests when overloaded rather than accepting and failing slowly)
+- Queue depths are bounded
+- Resource consumption (memory, connections, threads) has defined limits
+- Load shedding prioritises critical over non-critical work
+
+**Partially met:**
+- Some capacity limits exist but not comprehensive (e.g., queue depth bounded but no request admission control)
+- Limits exist but are not tested under load
+
+**Not met:**
+- No capacity limits — system accepts all work regardless of load
+- Unbounded queues or resource pools
+
+### Criterion 3.3: Failure scenarios are codified as automated tests
+
+**Definition:** Known failure modes are tested, not just hoped-for.
+
+**Met (sufficient):**
+- Tests exist for key failure scenarios: dependency timeout, dependency error, invalid input, resource exhaustion
+- Tests verify the system's behaviour under failure (graceful degradation, correct error response), not just that it doesn't crash
+- Failure tests are part of the CI pipeline
+
+**Partially met:**
+- Some failure tests exist but coverage is spotty
+- Failure tests exist but only check "doesn't crash", not correct behaviour
+
+**Not met:**
+- No failure-scenario tests
+- Only happy-path tests
+
+### Criterion 3.4: Resource consumption is bounded and observable
+
+**Definition:** The system's resource usage can be seen and is constrained.
+
+**Met (sufficient):**
+- Resource metrics are emitted: memory usage, connection pool utilisation, thread pool usage, queue depth
+- Resource limits are configured (container memory limits, connection pool sizes, thread pool sizes)
+- Resource consumption can be correlated with request load (to identify leaks and scaling needs)
+
+**Partially met:**
+- Some resource metrics exist but not comprehensive
+- Limits are configured but resource usage isn't observable (or vice versa)
+
+**Not met:**
+- No resource metrics
+- No resource limits configured

--- a/spec/sre/references.md
+++ b/spec/sre/references.md
@@ -1,0 +1,130 @@
+# References — SRE Domain
+
+> Source attribution for all frameworks, concepts, and terminology used in the SRE review domain. Cite these when asked about the origin of a concept. Update this file when new sources are introduced.
+
+## Framework Origins
+
+### ROAD (Response, Observability, Availability, Delivery)
+
+**Origin:** Bruce Dominguez
+**Status:** External framework adopted as the structural backbone of the SRE review domain.
+**How it's used:** Organises the SRE review into 4 pillars, each with a dedicated subagent. Every SRE review runs all 4 pillars in parallel.
+
+### SEEMS (Shared fate, Excessive load, Excessive latency, Misconfiguration, Single points of failure)
+
+**Origin:** To be confirmed. The acronym and categories appear to derive from common SRE failure taxonomy. If this is original to the project, declare it as such. If it comes from a specific author or publication, cite here.
+**Status:** Used as the "offensive" analytical lens — identifies how code can fail.
+**How it's used:** Each ROAD pillar focuses on specific SEEMS categories (see `framework-map.md`). Findings are categorised by SEEMS failure mode.
+
+### FaCTOR (Fault isolation, Availability, Capacity, Timeliness, Output correctness, Redundancy)
+
+**Origin:** To be confirmed. Similar attribution question as SEEMS.
+**Status:** Used as the "defensive" analytical lens — verifies resilience properties.
+**How it's used:** Paired with SEEMS to form the duality (attack/defence). Recommendations suggest strengthening specific FaCTOR properties.
+
+### Maturity Model (Hygiene, L1, L2, L3)
+
+**Origin:** Original to this project.
+**Design history:**
+- PR #13/Issue #13: Initial maturity scoring concept — hygiene factors vs aspirational targets
+- PR #18: Added domain-specific maturity criteria to all 4 review domains
+- PR #19: Rewrote as universal Hygiene gate (Irreversible/Total/Regulated) with outcome-based levels. Removed technique names from criteria.
+
+**Key design decision (PR #19):** The Hygiene gate uses consequence-severity tests, not domain-specific checklists. This ensures the same escalation logic across Architecture, SRE, Security, and Data domains.
+
+## Books and Publications
+
+### Site Reliability Engineering (Google SRE Book)
+
+**Authors:** Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy
+**Published:** 2016, O'Reilly Media
+**ISBN:** 978-1491929124
+**Relevance:** Foundational SRE concepts — SLOs, error budgets, toil reduction, incident response, postmortem culture. Informs the Availability and Response pillars.
+**Specific chapters referenced:**
+- Chapter 4: Service Level Objectives
+- Chapter 6: Monitoring Distributed Systems
+- Chapter 14: Managing Incidents
+- Chapter 21: Handling Overload
+
+### The Site Reliability Workbook
+
+**Authors:** Betsy Beyer, Niall Richard Murphy, David K. Rensin, Kent Kawahara, Stephen Thorne
+**Published:** 2018, O'Reilly Media
+**ISBN:** 978-1492029502
+**Relevance:** Practical implementation guidance for SLOs, alerting, and on-call. Informs maturity criteria definitions.
+
+### Release It! (2nd Edition)
+
+**Authors:** Michael T. Nygard
+**Published:** 2018, Pragmatic Bookshelf
+**ISBN:** 978-1680502398
+**Relevance:** Stability patterns (circuit breakers, bulkheads, timeouts, governors) and anti-patterns (cascading failures, blocked threads, integration point failures). Directly informs the Availability pillar and the SEEMS/FaCTOR categories.
+**Specific patterns referenced:**
+- Circuit Breaker (Chapter 5)
+- Bulkhead (Chapter 5)
+- Timeout (Chapter 5)
+- Steady State (Chapter 5)
+- Fail Fast (Chapter 5)
+- Handshaking (Chapter 5)
+- Governor (Chapter 5)
+
+### Implementing Service Level Objectives
+
+**Authors:** Alex Hidalgo
+**Published:** 2020, O'Reilly Media
+**ISBN:** 978-1492076810
+**Relevance:** Deep guidance on SLI selection, SLO definition, error budget policies. Informs L2 maturity criteria around SLO measurability.
+
+### Observability Engineering
+
+**Authors:** Charity Majors, Liz Fong-Jones, George Miranda
+**Published:** 2022, O'Reilly Media
+**ISBN:** 978-1492076445
+**Relevance:** Observability vs monitoring distinction, structured events, high-cardinality data. Informs the Observability pillar.
+
+### Domain-Driven Design
+
+**Authors:** Eric Evans
+**Published:** 2003, Addison-Wesley
+**ISBN:** 978-0321125217
+**Relevance:** Bounded contexts, aggregate boundaries. Referenced in the Architecture domain but also relevant to SRE (service boundaries = failure boundaries).
+
+## Standards and Industry References
+
+### OWASP Top 10
+
+**URL:** https://owasp.org/www-project-top-ten/
+**Relevance:** Referenced primarily in the Security domain, but items like "Security Misconfiguration" and "Server-Side Request Forgery" have SRE overlap via the Misconfiguration SEEMS category.
+
+### The Twelve-Factor App
+
+**URL:** https://12factor.net/
+**Relevance:** Config management (Factor III), backing services (Factor IV), logs as event streams (Factor XI). Informs the Delivery and Observability pillars.
+
+### OpenTelemetry Specification
+
+**URL:** https://opentelemetry.io/docs/specs/
+**Relevance:** Defines the standard for metrics, logs, and traces. The Observability pillar's checklist items (structured logging, span attributes, metric types) align with OpenTelemetry conventions without requiring it specifically.
+
+## Project History
+
+Key PRs that shaped the SRE domain, in chronological order:
+
+| PR | What changed | Design impact |
+|----|-------------|---------------|
+| #3 | Initial SRE review system | Established ROAD + SEEMS/FaCTOR architecture, 4 subagents, prompt structure |
+| #17 | "SPOF" renamed to "Single points of failure" | Terminology consistency with SEEMS framework definition |
+| #18 | Cascading maturity model added | Domain-specific maturity criteria (HYG/L1/L2/L3) in `_base.md` and `SKILL.md` |
+| #19 | Universal Hygiene gate, outcome-based levels | Removed technique names from criteria. Hygiene uses consequence-severity tests. Observability checklist refined from "metrics suitable for alerting" to "signal presence". |
+| #21 | Batch orchestrator `/review-all` | SRE runs as one of 4 parallel domains, results in `sre.md` sub-report |
+| #23 | Namespace attempt (closed) | Skill namespacing via subdirectories didn't work. Led to plugin-based approach (`donkey-dev/`). |
+
+## Attribution Gaps
+
+The following require source confirmation:
+
+| Term | Current status | Action needed |
+|------|---------------|---------------|
+| SEEMS | Used throughout prompts, no citation | Confirm if original to Bruce Dominguez / ROAD framework, or from another source |
+| FaCTOR | Used throughout prompts, no citation | Same — confirm origin |
+| ROAD | Attributed to Bruce Dominguez in PR #3 | Confirm specific publication or talk |

--- a/spec/sre/spec.md
+++ b/spec/sre/spec.md
@@ -1,0 +1,207 @@
+# SRE Domain Specification
+
+> Canonical reference for building, improving, and maintaining the SRE review domain within the donkey-dev Claude Code plugin.
+
+## 1. Purpose
+
+The SRE review domain evaluates code changes through the lens of operational reliability. It answers one question: **"If we ship this, what will 3am look like?"**
+
+The domain produces a structured maturity assessment that tells engineering leaders:
+- What will break in production (Hygiene failures)
+- What foundations are missing (L1 gaps)
+- What operational maturity looks like for this codebase (L2 criteria)
+- What excellence would require (L3 aspirations)
+
+## 2. Audience
+
+| Who | Uses the spec for |
+|-----|-------------------|
+| **Autonomous coding agents** | Building/modifying prompt files, agent definitions, skill orchestrators |
+| **Human prompt engineers** | Reviewing agent output, calibrating severity, refining checklists |
+| **Plugin consumers** | Understanding what the SRE review evaluates and why |
+
+## 3. Conceptual Architecture
+
+The SRE domain is built from three interlocking layers:
+
+```
++----------------------------------------------+
+|          ROAD Framework (Structure)          |   Organises WHAT to review
+|  Response . Observability .                  |
+|  Availability . Delivery                     |
++----------------------------------------------+
+|    SEEMS (Attack)  <-->  FaCTOR (Defence)    |   Analytical LENSES
+|    "How will this      "What protects        |
+|     fail?"              against it?"         |
++----------------------------------------------+
+|         Maturity Model (Judgement)            |   Calibrates SEVERITY
+|    Hygiene --> L1 --> L2 --> L3               |   and PRIORITY
++----------------------------------------------+
+```
+
+- **ROAD** provides the structural decomposition (4 pillars, 4 subagents).
+- **SEEMS** and **FaCTOR** provide the analytical lenses applied within each pillar.
+- **The Maturity Model** provides the judgement framework for prioritising findings.
+
+These layers are defined in detail in the companion files:
+- `glossary.md` — canonical definitions
+- `framework-map.md` — how SEEMS, FaCTOR, and ROAD relate to each other
+- `maturity-criteria.md` — detailed criteria with "sufficient" thresholds
+- `calibration.md` — worked examples showing severity judgement
+- `anti-patterns.md` — concrete code smells per pillar
+- `references.md` — source attribution
+
+## 4. File Layout
+
+The SRE domain manifests as these files within the plugin:
+
+```
+donkey-dev/
+  agents/
+    sre-response.md          # Subagent: incident response readiness
+    sre-observability.md     # Subagent: logging, metrics, tracing
+    sre-availability.md      # Subagent: SLOs, resilience, load management
+    sre-delivery.md          # Subagent: deployment safety, rollback
+  prompts/sre/
+    _base.md                 # Shared context: SEEMS, FaCTOR, maturity model, output format
+    response.md              # Response pillar checklist
+    observability.md         # Observability pillar checklist
+    availability.md          # Availability pillar checklist
+    delivery.md              # Delivery pillar checklist
+  skills/
+    review-sre/SKILL.md      # Orchestrator: scope, parallel dispatch, synthesis, output
+```
+
+### Composition rules
+
+1. **Each agent file is self-contained.** It embeds the full content of `_base.md` + its pillar prompt. Agents do not reference external files at runtime — all context must be inlined.
+2. **Prompts are the source of truth.** The `prompts/sre/` directory contains the human-readable, LLM-agnostic checklists. Agent files are compiled from these.
+3. **The skill orchestrator dispatches and synthesises.** It does not contain review logic — that lives in the agents.
+
+### When modifying files
+
+| Change type | Files to update |
+|-------------|-----------------|
+| Add/change a checklist item | `prompts/sre/<pillar>.md` then recompile the corresponding `agents/sre-<pillar>.md` |
+| Change shared context (severity, maturity, output format) | `prompts/sre/_base.md` then recompile ALL 4 agent files |
+| Change orchestration logic | `skills/review-sre/SKILL.md` only |
+| Add a new ROAD pillar | New prompt file, new agent file, update SKILL.md to spawn 5th agent |
+
+## 5. Design Principles
+
+These principles govern all prompt changes in the SRE domain. They emerged from the project's evolution (PRs #3, #17, #18, #19) and must be preserved.
+
+### 5.1 Outcomes over techniques
+
+Maturity criteria describe **observable outcomes**, not named techniques or libraries.
+
+| Bad (technique) | Good (outcome) |
+|-----------------|----------------|
+| "Circuit breakers exist" | "External dependencies have failure isolation" |
+| "Uses structured logging" | "Logging is structured with request correlation" |
+| "Has Prometheus metrics" | "SLI-relevant metrics are exposed and measurable" |
+| "Implements SEEMS/FaCTOR" | "Failure modes are identified and resilience properties verified" |
+
+**Rationale (PR #19):** Technique names create false negatives — a team using Polly for retries with backoff satisfies the outcome but wouldn't match "uses Resilience4j". Outcomes are technology-neutral and verifiable from code.
+
+### 5.2 Questions over imperatives
+
+Checklists use questions to prompt investigation, not imperatives to demand compliance.
+
+| Bad (imperative) | Good (question) |
+|-------------------|-----------------|
+| "Ensure requests are traceable" | "Can you trace a request through the system?" |
+| "Add timeouts to all calls" | "Do all external calls have timeouts? Are they appropriate?" |
+
+**Rationale:** Questions guide the reviewer to investigate the code and form a judgement. Imperatives produce binary "present/absent" assessments that miss nuance.
+
+### 5.3 Concrete anti-patterns
+
+Anti-pattern descriptions include specific code-level examples, not abstract categories.
+
+| Bad (abstract) | Good (concrete) |
+|-----------------|-----------------|
+| "Poor error handling" | "Generic error messages: 'An error occurred' / 'Something went wrong'" |
+| "Inadequate logging" | "`console.log` / `print` statements instead of structured logging" |
+
+### 5.4 Positive observations required
+
+Every review MUST include a "What's Good" section. Reviews that only list problems are demoralising and less actionable. Positive patterns give teams confidence about what to preserve.
+
+### 5.5 Hygiene gate is consequence-based
+
+The Hygiene gate uses three consequence-severity tests (Irreversible, Total, Regulated), not domain-specific checklists. This ensures consistent escalation logic across all domains.
+
+### 5.6 Severity is about production impact
+
+| Level | Definition | Decision |
+|-------|-----------|----------|
+| **HIGH** | Could cause outage, data loss, or significant degradation | Must fix before merge |
+| **MEDIUM** | Operational risk that should be addressed | May require follow-up ticket |
+| **LOW** | Minor improvement opportunity | Nice to have |
+
+Severity is about the **production consequence** if the code ships as-is, not about how hard the fix is.
+
+## 6. Orchestration Process
+
+The `/review-sre` skill follows this process:
+
+### Step 1: Scope identification
+
+- File or directory argument: review that path
+- Empty or ".": review recent changes (`git diff`) or prompt for scope
+- PR number: fetch the diff
+
+### Step 2: Parallel dispatch
+
+Spawn 4 subagents simultaneously:
+
+| Agent | Model | Rationale |
+|-------|-------|-----------|
+| `sre-response` | sonnet | Nuanced judgement on error message quality and runbook readiness |
+| `sre-observability` | sonnet | Complex analysis of logging/metrics/tracing completeness |
+| `sre-availability` | sonnet | Subtle resilience pattern analysis |
+| `sre-delivery` | haiku | More binary checklist (backward-compatible or not, reversible or not) |
+
+### Step 3: Synthesis
+
+1. **Collect** findings from all 4 pillars
+2. **Deduplicate** — when two agents flag the same `file:line`, merge into one finding:
+   - Take the **highest severity**
+   - Take the **most restrictive maturity level** (HYG > L1 > L2 > L3)
+   - Combine recommendations from both agents
+   - Credit both pillars in the Category column (e.g., "Availability / Response")
+3. **Aggregate maturity** — merge per-criterion assessments into one view:
+   - All criteria met = `pass`
+   - Mix of met and not met = `partial`
+   - All criteria not met = `fail`
+   - Previous level not passed = `locked`
+4. **Prioritise** — HYG findings first, then by severity (HIGH > MEDIUM > LOW)
+
+### Step 4: Output
+
+Produce the maturity assessment report per the output format defined in `_base.md`.
+
+## 7. Improvement Vectors
+
+Known gaps that future work should address, in priority order:
+
+| # | Gap | Impact | Direction |
+|---|-----|--------|-----------|
+| 1 | **SEEMS-FaCTOR duality unlinked** | Reviewers treat them as separate checklists | Add explicit mapping: "this SEEMS failure is mitigated by this FaCTOR property" (see `framework-map.md`) |
+| 2 | **No calibration examples** | Severity judgements are inconsistent across runs | Add worked examples per severity per pillar (see `calibration.md`) |
+| 3 | **L1 "sufficient" is undefined** | "Errors propagate with context sufficient for diagnosis" is subjective | Define minimum thresholds (see `maturity-criteria.md`) |
+| 4 | **Deduplication rules were implicit** | Synthesis step produced inconsistent merges | Now defined in Section 6 above |
+| 5 | **No technology-specific supplements** | Checklists can't recognise framework-specific patterns | Future: add optional supplements for Python, Java, Go, Node, .NET |
+| 6 | **SLO treatment is shallow** | SLOs mentioned but not operationalised | Future: add concrete guidance on SLO-aligned code patterns |
+| 7 | **No confidence signal** | Agents can't express uncertainty | Future: add optional confidence qualifier (confirmed / likely / possible) |
+| 8 | **No cross-review learning** | Each review is stateless | Future: use `.code-review/` history to track maturity progression |
+
+## 8. Constraints
+
+Things the SRE domain deliberately does NOT do:
+
+- **No auto-fix.** The review is read-only. Agents have Read, Grep, Glob tools only — no Bash, no Write, no Edit.
+- **No cross-domain findings.** SRE does not flag architecture, security, or data issues. Those belong to their respective domains.
+- **No numeric scores.** Status is pass/partial/fail/locked. No percentages, no weighted scores.
+- **No prescribing specific tools.** Never recommend a specific library or vendor. Describe the outcome, let the team choose the implementation.


### PR DESCRIPTION
## Summary
- Add `spec/sre-spec.md` placeholder linking to the full spec
- Add `spec/sre/spec.md` — the canonical SRE domain specification defining the ROAD structural framework (Response, Observability, Availability, Delivery), SEEMS/FaCTOR analytical lenses, maturity model, orchestration process, design principles, and constraints
- Add 6 companion documents:
  - `glossary.md` — canonical definitions for all SRE terms and frameworks
  - `framework-map.md` — how SEEMS, FaCTOR, and ROAD interrelate
  - `maturity-criteria.md` — detailed criteria with "sufficient" thresholds per level
  - `calibration.md` — worked examples for severity and maturity judgement
  - `anti-patterns.md` — concrete code smells organised by ROAD pillar
  - `references.md` — source attribution for all frameworks and concepts

## Test plan
- [ ] Verify spec structure is consistent: all sections referenced in `spec.md` Section 3 have corresponding companion files
- [ ] Verify glossary covers all acronyms used across the spec (ROAD, SEEMS, FaCTOR, SLO, SLI)
- [ ] Verify framework-map correctly links SEEMS failure modes to FaCTOR defence properties
- [ ] Verify maturity-criteria covers all four levels (Hygiene, L1, L2, L3) for each ROAD pillar
- [ ] Verify file layout in Section 4 matches the planned plugin directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)