### PR TITLE
Add Architecture domain specification

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -17,3 +17,6 @@ This file provides guidance on where to find standards and specifications for th
 
 - SRE, Site Reliability Engineering, Availability, Observability, Incident Response, CI/CD, Deployment - ./sre/spec.md
 - Security, Confidentiality, Privacy, Threat, Vulnerability, Defence, Authorisation, Authentication, Audit - ./sec/spec.md
+- Architecture, code, service, system, landscape, anti-patterns, standards, Performance, Cost, Affordability, Modular, Modularity, Composability, Composition, Scalability, Scale, Scalable, Modifiability, Modifiable, Portability, Integrability, Integration Reusability, Reuse, Testing - ./arc/spec.md
+
+

--- a/spec/arc/anti-patterns.md
+++ b/spec/arc/anti-patterns.md
@@ -1,0 +1,395 @@
+# Anti-Patterns Catalogue — Architecture Domain
+
+> Complete catalogue of structural patterns that Architecture reviewers should flag. Organised by zoom level, with design principle classification and typical severity.
+
+## How to use this document
+
+Each anti-pattern includes:
+- **Pattern name** — a short, memorable label
+- **What it looks like** — concrete code or structural description
+- **Why it's bad** — structural impact over time
+- **Design principle violated** — which cross-cutting principle is eroded
+- **Typical severity** — default assessment (may be higher or lower depending on context)
+
+When adding new anti-patterns to prompts, follow this structure. Use concrete descriptions, not abstract categories.
+
+---
+
+## Code Level Anti-Patterns
+
+### CL-01: God class
+
+**What it looks like:** A class with too many responsibilities — more than ~500 lines, more than ~10 dependencies, methods that operate on unrelated data. Often named `*Manager`, `*Service`, `*Helper`, `*Utils`.
+
+**Why it's bad:** Every change to any responsibility risks breaking the others. Testing requires constructing the entire class with all its dependencies. The class becomes a merge conflict magnet. New developers can't understand it in a reasonable time.
+
+**Design principle:** Separation of Concerns
+**Typical severity:** HIGH / L1
+
+### CL-02: Circular dependency
+
+**What it looks like:** Module A imports from Module B, and Module B imports from Module A (directly or transitively).
+
+**Why it's bad:** Neither module can be extracted, tested, or deployed independently. Changes to either module may break the other. Circular dependencies compound — once one exists, more are attracted into the cycle.
+
+**Design principle:** Loose Coupling
+**Typical severity:** HIGH / HYG (Total — if the cycle spans services, one failure cascades to all participants)
+
+### CL-03: Leaky abstraction — persistence in domain
+
+**What it looks like:** Domain classes import ORM or persistence frameworks. `@Entity`, `@Column`, `@Table` annotations on domain objects. SQLAlchemy `Column` types in domain models.
+
+```python
+# BAD: Domain depends on infrastructure
+from sqlalchemy import Column, Integer, String
+
+class Order:
+    id = Column(Integer, primary_key=True)
+    status = Column(String)
+```
+
+**Why it's bad:** The domain model can't be tested without a database. Changing the persistence layer requires rewriting domain logic. The ORM's constraints leak into business rules.
+
+**Design principle:** Loose Coupling, Testability
+**Typical severity:** HIGH / L1
+
+### CL-04: Primitive obsession
+
+**What it looks like:** Using raw strings for emails, raw ints for IDs, raw floats for money, raw strings for currencies — instead of typed value objects.
+
+```python
+# BAD: Primitives everywhere
+def create_order(user_id: int, email: str, amount: float, currency: str): ...
+
+# GOOD: Value objects
+def create_order(user_id: UserId, email: Email, price: Money): ...
+```
+
+**Why it's bad:** No validation at the type level — invalid emails, negative money, wrong currency pairs all compile and pass. Business rules about these concepts are scattered across the codebase instead of encapsulated.
+
+**Design principle:** High Cohesion, Explicit over Implicit
+**Typical severity:** MEDIUM / L1
+
+### CL-05: Anemic domain model
+
+**What it looks like:** Classes with only getters/setters and no behaviour. All business logic lives in separate "service" classes that operate on dumb data containers.
+
+**Why it's bad:** Domain knowledge is scattered across service classes rather than encapsulated in the entities that own the data. The "service" classes become God classes. The domain model communicates nothing about business rules.
+
+**Design principle:** High Cohesion
+**Typical severity:** MEDIUM / L1
+
+### CL-06: Feature envy
+
+**What it looks like:** A method that uses another class's data more than its own. Chains of `obj.getX().getY().doZ()` — reaching deep into another object's structure.
+
+**Why it's bad:** The method should probably live on the class it's envying. The calling class knows too much about the other's internal structure. Changes to the other class break the calling method.
+
+**Design principle:** High Cohesion, Loose Coupling
+**Typical severity:** MEDIUM / L1
+
+### CL-07: Deep inheritance hierarchy
+
+**What it looks like:** More than 2-3 levels of class inheritance. Abstract base classes with many methods, some overridden, some not.
+
+**Why it's bad:** Behaviour is distributed across the hierarchy — you must read all parent classes to understand a method's full behaviour. Liskov Substitution violations are common. Changes to base classes ripple unpredictably.
+
+**Design principle:** Separation of Concerns, Testability
+**Typical severity:** MEDIUM / L2
+
+### CL-08: Hidden dependencies
+
+**What it looks like:** A class constructs its own dependencies internally rather than receiving them through injection. Uses of `new`, `static` factory methods, service locators, or global state inside business logic.
+
+**Why it's bad:** Can't substitute dependencies for testing. Can't change implementations without modifying the class. The dependency graph is invisible from the constructor/public interface.
+
+**Design principle:** Testability, Explicit over Implicit
+**Typical severity:** MEDIUM / L1
+
+### CL-09: Inconsistent naming (ubiquitous language violation)
+
+**What it looks like:** The same domain concept referred to by multiple names: "Portfolio" in the API, "Orders" in the database, "Basket" in the UI. Or technical implementation names in the domain layer ("DbRecord", "HttpHandler") instead of domain terms.
+
+**Why it's bad:** New developers can't map between business requirements and code. Domain experts can't review or validate the model. Miscommunication between teams becomes structural.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** MEDIUM / L1
+
+### CL-10: Dead code and premature abstraction
+
+**What it looks like:** Interfaces with only one implementation ("just in case"). Abstract factories for a single variant. Unused code paths that "might be needed later". YAGNI violations.
+
+**Why it's bad:** Adds cognitive load without value. The abstraction may be wrong for the actual future requirement. Dead code misleads — developers assume it's used.
+
+**Design principle:** Separation of Concerns
+**Typical severity:** LOW / L2
+
+---
+
+## Service Level Anti-Patterns
+
+### SL-01: Shared database
+
+**What it looks like:** Two services reading from or writing to the same database tables. Direct SQL access to another service's schema. Shared ORMs or database models.
+
+**Why it's bad:** Creates invisible coupling — changes to the schema by one team break the other. Independent deployment is impossible. Data ownership is ambiguous. Migrations become coordinated events.
+
+**Design principle:** Loose Coupling, Explicit over Implicit
+**Typical severity:** HIGH / HYG (Irreversible — if both services write to shared tables, data corruption can occur. Total — schema changes cascade to all consumers)
+
+### SL-02: Distributed monolith
+
+**What it looks like:** Services that must be deployed together. Shared libraries containing domain logic. Synchronous call chains where all services must be running for any to work.
+
+**Why it's bad:** All the operational complexity of microservices with none of the benefits. Deployment is all-or-nothing. A failure in one service cascades to all. Teams can't work independently.
+
+**Design principle:** Loose Coupling
+**Typical severity:** HIGH / HYG (Total — one deployment failure or service outage cascades to all)
+
+### SL-03: Domain logic in controllers
+
+**What it looks like:** Business rules implemented in HTTP handlers, API controllers, or message handlers. Validation, calculation, and orchestration in the request handling layer.
+
+```python
+# BAD: Domain logic in HTTP handler
+@app.route("/orders", methods=["POST"])
+def create_order():
+    if request.json["total"] > 1000:
+        # Apply discount - this is domain logic!
+        request.json["total"] *= 0.9
+    db.session.add(Order(**request.json))
+```
+
+**Why it's bad:** The business logic can't be tested without HTTP. It can't be reused from a CLI, message handler, or scheduled job. The controller grows into a God class. The "domain" is invisible — it exists only in the plumbing.
+
+**Design principle:** Separation of Concerns, Testability
+**Typical severity:** HIGH / L1
+
+### SL-04: Service too broad
+
+**What it looks like:** A single service serving multiple bounded contexts — unrelated features, different change cadences, different stakeholders. Often identifiable by "AND" in the service description: "manages users AND handles billing AND sends notifications".
+
+**Why it's bad:** Every team's changes risk breaking other teams' features. The service grows without bound. Deployment frequency is constrained by the slowest-moving feature. The domain model becomes internally inconsistent.
+
+**Design principle:** Separation of Concerns, High Cohesion
+**Typical severity:** MEDIUM / L1
+
+### SL-05: Missing Anti-Corruption Layer
+
+**What it looks like:** External DTOs or upstream models used directly throughout domain code. Third-party data structures passed into business logic without translation.
+
+**Why it's bad:** The upstream system's model dictates the downstream domain's structure. When the upstream changes, ripple effects propagate deep into domain logic. The downstream team loses control of their own model.
+
+**Design principle:** Loose Coupling, Explicit over Implicit
+**Typical severity:** MEDIUM / L1
+
+### SL-06: Chatty interface
+
+**What it looks like:** A client needs 5+ API calls to complete one logical operation. Fine-grained CRUD endpoints with no aggregate operations.
+
+**Why it's bad:** Network latency is multiplied. Partial failure handling becomes complex (3 of 5 calls succeed — now what?). Clients must understand the service's internal structure to compose the correct sequence.
+
+**Design principle:** High Cohesion, Explicit over Implicit
+**Typical severity:** MEDIUM / L2
+
+### SL-07: Missing error hierarchy
+
+**What it looks like:** All errors treated the same — no distinction between transient (timeout, rate limit), permanent (validation failure, not found), and infrastructure (connection refused, disk full) errors.
+
+**Why it's bad:** Clients can't make correct retry decisions. Operators can't distinguish "expected" errors from "requires investigation" errors. Monitoring treats all errors as equal severity.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** MEDIUM / L1
+
+### SL-08: Layer bypass
+
+**What it looks like:** Some features follow the layered architecture (domain → application → infrastructure), others skip layers — a controller calling the database directly, or infrastructure calling domain objects directly.
+
+**Why it's bad:** Inconsistent architecture is harder to reason about than consistently wrong architecture. Developers don't know which pattern to follow. The bypass becomes the precedent for future shortcuts.
+
+**Design principle:** Separation of Concerns
+**Typical severity:** LOW / L1
+
+---
+
+## System Level Anti-Patterns
+
+### YL-01: Unprotected integration point
+
+**What it looks like:** External call with no timeout, no circuit breaker, no error handling. A raw HTTP/gRPC call to a downstream service with no protection.
+
+```python
+# BAD: No timeout, no circuit breaker
+response = requests.get(f"http://downstream/api/data")
+
+# GOOD: Protected with timeout and circuit breaker
+response = requests.get(
+    f"http://downstream/api/data",
+    timeout=(3, 10)
+)
+```
+
+**Why it's bad:** A slow or failing dependency can block all calling threads. Under dependency failure, the caller becomes unresponsive. This is "the number-one killer of systems" (Nygard).
+
+**Design principle:** Loose Coupling, Explicit over Implicit
+**Typical severity:** HIGH / HYG (Total — can render the entire calling service unresponsive)
+
+### YL-02: Cascading failure path
+
+**What it looks like:** A synchronous call chain (A → B → C → D) where one service's failure brings down all upstream callers. No bulkheads, no circuit breakers, no fallbacks between services.
+
+**Why it's bad:** The blast radius of any single service failure is the entire chain. Recovery requires restarting in reverse order. The weakest service determines the reliability of the entire chain.
+
+**Design principle:** Loose Coupling
+**Typical severity:** HIGH / HYG (Total — one failure cascades beyond its boundary)
+
+### YL-03: Unbounded result sets
+
+**What it looks like:** Cross-service queries that return unbounded results — `getAllOrders()`, `findUsers()` with no pagination, limit, or streaming.
+
+```python
+# BAD: Could return millions of records
+orders = order_service.get_all_orders()
+
+# GOOD: Bounded and paginated
+orders = order_service.get_orders(page=1, limit=100)
+```
+
+**Why it's bad:** Memory exhaustion. Network saturation. Timeout cascades. One large response can overwhelm the caller, the network, and the downstream service simultaneously.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** HIGH / L1
+
+### YL-04: Shared database across services
+
+**What it looks like:** Multiple services accessing the same database tables. One service writing, another reading. Shared connection pools or database credentials.
+
+**Why it's bad:** Schema changes break unknown consumers. Locking contention between services causes unpredictable latency. Data ownership is ambiguous — who decides the schema?
+
+**Design principle:** Loose Coupling
+**Typical severity:** HIGH / HYG (Total — schema change by one team breaks all services using the table)
+
+### YL-05: Temporal coupling
+
+**What it looks like:** Service A must call B before C. Operations have implicit ordering requirements that aren't enforced by the API.
+
+**Why it's bad:** Out-of-order calls produce silent data corruption or confusing errors. The ordering constraint exists only in developer knowledge, not in the code.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** MEDIUM / L2
+
+### YL-06: Missing contract
+
+**What it looks like:** Services communicate via HTTP/gRPC/messaging with no formal contract definition — no OpenAPI, no Protobuf, no AsyncAPI. "It just calls that endpoint."
+
+**Why it's bad:** Breaking changes are discovered at runtime, not at build time. Consumer expectations are undocumented. Version management is impossible.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** MEDIUM / L1
+
+### YL-07: Dogpile / thundering herd
+
+**What it looks like:** All instances expire cache entries at the same time, all hit the database simultaneously. Or: all clients that failed retry at the same moment.
+
+**Why it's bad:** Creates a periodic spike of load on the downstream service. Can cause cascading failure if the spike exceeds the downstream's capacity.
+
+**Design principle:** Loose Coupling
+**Typical severity:** MEDIUM / L2
+
+### YL-08: Synchronous call to non-critical dependency
+
+**What it looks like:** A user-facing request handler that makes a synchronous call to analytics, recommendations, audit logging, or other non-critical services in the request path.
+
+**Why it's bad:** Non-critical dependency failure degrades or blocks the critical user-facing path. The non-critical service effectively becomes a hard dependency.
+
+**Design principle:** Separation of Concerns
+**Typical severity:** MEDIUM / L2
+
+---
+
+## Landscape Level Anti-Patterns
+
+### LL-01: Distributed big ball of mud
+
+**What it looks like:** No clear boundaries between systems. Everything calls everything. Any change requires coordinating across many teams. No context map exists.
+
+**Why it's bad:** Change velocity slows to the speed of the slowest team. Integration failures are unpredictable. Nobody understands the full system. Ownership is ambiguous.
+
+**Design principle:** Separation of Concerns, Explicit over Implicit
+**Typical severity:** HIGH / L1
+
+### LL-02: Undocumented integration points
+
+**What it looks like:** Services connected with no formal contract. "It just calls that endpoint." No OpenAPI, no AsyncAPI, no documented message formats.
+
+**Why it's bad:** Breaking changes are discovered in production. New teams can't integrate without tribal knowledge. Migration paths are invisible.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** HIGH / L1
+
+### LL-03: Shared database across system boundaries
+
+**What it looks like:** Multiple systems (owned by different teams or organisations) writing to the same database.
+
+**Why it's bad:** All the problems of shared database at the service level, compounded by organisational boundaries. Schema governance is a political nightmare. Data ownership disputes become inter-team conflicts.
+
+**Design principle:** Loose Coupling
+**Typical severity:** HIGH / HYG (Irreversible — data corruption across organisational boundaries)
+
+### LL-04: Missing ADRs for significant decisions
+
+**What it looks like:** Major technology or architecture choices with no documented rationale. "Why did we choose Kafka?" — nobody knows. Decisions live only in people's heads.
+
+**Why it's bad:** The next team to encounter the constraint will re-evaluate the same options, possibly making an inconsistent choice. When the decision-maker leaves, the rationale leaves with them.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** MEDIUM / L2
+
+### LL-05: Stale documentation / design-code drift
+
+**What it looks like:** Tech-spec or design docs that don't match the current codebase. ADRs accepted but tech-spec unchanged. Code evolved beyond what any documentation describes.
+
+**Why it's bad:** Documentation becomes actively misleading — worse than no documentation. New developers make incorrect assumptions. Architecture reviews assess the wrong system.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** MEDIUM / L2
+
+### LL-06: Spaghetti integration
+
+**What it looks like:** Point-to-point connections everywhere. N services with N*(N-1)/2 direct connections. No event bus, no API gateway, no shared messaging infrastructure.
+
+**Why it's bad:** Adding a new service requires connecting to every existing service. Connection failures are multiplicative. No single place to observe or manage cross-system communication.
+
+**Design principle:** Loose Coupling
+**Typical severity:** MEDIUM / L2
+
+### LL-07: Golden hammer
+
+**What it looks like:** Same technology for every problem — Kafka for request/response, REST for event streaming, relational database for everything.
+
+**Why it's bad:** Forces inappropriate design patterns. Teams fight the tool instead of solving the problem. Technical debt accumulates when workarounds replace proper solutions.
+
+**Design principle:** Separation of Concerns
+**Typical severity:** MEDIUM / L2
+
+### LL-08: No fitness functions
+
+**What it looks like:** Architecture standards exist on paper but aren't enforced. No automated tests for layer violations, circular dependencies, API compatibility, or performance budgets.
+
+**Why it's bad:** Architecture erodes silently. Layer violations accumulate. Circular dependencies appear one import at a time. By the time anyone notices, the cost of correction is prohibitive.
+
+**Design principle:** Explicit over Implicit
+**Typical severity:** LOW / L3 (escalates to MEDIUM if architectural standards exist but aren't enforced)
+
+---
+
+## Adding New Anti-Patterns
+
+When adding a new anti-pattern to this catalogue or to the prompts:
+
+1. Give it a **short, memorable name** (not "Bad Practice #7")
+2. Describe **what it looks like** in code or structure (concrete, not abstract)
+3. Explain **why it's bad** in terms of structural impact over time
+4. Identify the **design principle** being violated
+5. Assign a **typical severity** with reasoning
+6. Note **boundary conditions** that would change the severity (especially HYG escalation)

--- a/spec/arc/calibration.md
+++ b/spec/arc/calibration.md
@@ -1,0 +1,308 @@
+# Calibration Examples — Architecture Domain
+
+> Worked examples showing how to judge severity and maturity level for real code patterns. Use these to calibrate prompt output and verify consistency across reviews.
+
+## How to use this document
+
+Each example shows:
+1. **Code pattern** — what the reviewer sees
+2. **Assessment** — severity, maturity level, zoom level
+3. **Reasoning** — why this severity and level, not higher or lower
+4. **Boundary note** — what would change the assessment up or down
+
+---
+
+## Code Level
+
+### Example C1: God class with mixed responsibilities (HIGH / L1)
+
+**Code pattern:**
+```python
+class OrderService:
+    def create_order(self, items): ...
+    def calculate_tax(self, amount): ...
+    def send_email(self, recipient): ...
+    def generate_pdf(self, order): ...
+    def validate_credit_card(self, card): ...
+    def sync_inventory(self, items): ...
+```
+
+**Assessment:** HIGH | L1 | Code | Separation of Concerns
+
+**Reasoning:** Six unrelated responsibilities in one class — order lifecycle, tax calculation, email delivery, PDF generation, payment validation, and inventory management. Each responsibility has different reasons to change and different stakeholders. Testing any one responsibility requires constructing all dependencies. This is a clear L1 gap (module boundaries not explicit) and HIGH because the structural debt compounds — this class will attract more responsibilities over time.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+class OrderService:
+    def create_order(self, items): ...
+    def update_order(self, order_id, changes): ...
+    def cancel_order(self, order_id): ...
+    def get_order(self, order_id): ...
+```
+Four related operations on the same aggregate. The class has a clear responsibility (order lifecycle) even if it could be further decomposed. This is a minor improvement opportunity, not a fundamental design flaw.
+
+**Boundary — would be HIGH / HYG if:** The God class handles both reads and writes to a shared database that other services also access (Total — changes cascade beyond the service boundary).
+
+### Example C2: Domain depends on infrastructure (HIGH / L1)
+
+**Code pattern:**
+```python
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+
+class Order:
+    __tablename__ = 'orders'
+    id = Column(Integer, primary_key=True)
+    customer_id = Column(Integer, ForeignKey('customers.id'))
+    status = Column(String(50))
+    items = relationship("OrderItem", back_populates="order")
+```
+
+**Assessment:** HIGH | L1 | Code | Loose Coupling / Testability
+
+**Reasoning:** The domain entity `Order` is inseparable from SQLAlchemy. You cannot test order business logic without a database. You cannot change the persistence layer without rewriting the domain model. The ORM's constraints (e.g., lazy loading, session management) leak into business logic. This is a clear L1 gap (dependencies flow outward instead of inward) and HIGH because it fundamentally prevents the dependency rule from being followed.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+# Domain layer
+class Order:
+    def __init__(self, id: OrderId, customer_id: CustomerId, status: OrderStatus):
+        self.id = id
+        self.customer_id = customer_id
+        self.status = status
+
+# Infrastructure layer
+class OrderMapping(Base):
+    __tablename__ = 'orders'
+    id = Column(Integer, primary_key=True)
+    # ... mapping code separate from domain
+```
+The domain is separated but the mapping layer doesn't translate between domain and persistence models cleanly — some ORM conventions leak through. This is a partial implementation (L1) but not a fundamental violation.
+
+### Example C3: Primitive obsession (MEDIUM / L1)
+
+**Code pattern:**
+```python
+def transfer_money(
+    from_account: str,     # Account ID as string
+    to_account: str,       # Account ID as string
+    amount: float,         # Money as float!
+    currency: str          # Currency as string
+):
+    if amount <= 0:
+        raise ValueError("Amount must be positive")
+    if currency not in ["USD", "EUR", "GBP"]:
+        raise ValueError("Invalid currency")
+```
+
+**Assessment:** MEDIUM | L1 | Code | High Cohesion
+
+**Reasoning:** Business concepts (Account ID, Money, Currency) are represented as primitives. Validation logic is scattered in every function that handles money. `float` for money is a well-known bug source (rounding errors). However, this is MEDIUM (not HIGH) because it's a local quality issue — it doesn't create systemic coupling or cascading risk. It's an L1 gap because the code works but lacks the type-level safety that prevents an entire class of bugs.
+
+**Boundary — would be HIGH / L1 if:** Multiple modules implement different validation rules for the same concept. One module accepts negative money amounts, another rejects them — the inconsistency is a business rule violation.
+
+**Boundary — would be LOW / L2 if:** Only one function uses these primitives, and it's an internal utility that's not part of the public API.
+
+### Example C4: Circular dependency between modules (HIGH / HYG)
+
+**Code pattern:**
+```python
+# order/service.py
+from billing.service import BillingService
+
+class OrderService:
+    def create_order(self, items):
+        billing = BillingService()
+        billing.charge(self.calculate_total(items))
+
+# billing/service.py
+from order.service import OrderService
+
+class BillingService:
+    def refund(self, order_id):
+        orders = OrderService()
+        order = orders.get_order(order_id)
+```
+
+**Assessment:** HIGH | HYG | Code | Loose Coupling (Total test: yes)
+
+**Reasoning:** A circular dependency between `order` and `billing` modules. Neither can be extracted, tested, or deployed independently. If these become separate services, the circular dependency becomes a distributed deadlock risk. This triggers the Total test because extracting these modules into separate deployable units (a natural architectural evolution) is blocked — the coupling cascades beyond the current boundary.
+
+**Boundary — would be HIGH / L1 if:** The cycle is within a single module (e.g., `order.models` imports `order.validation` which imports `order.models`). The coupling is bad but contained within one bounded context and fixable by restructuring the module.
+
+---
+
+## Service Level
+
+### Example S1: Shared database between services (HIGH / HYG)
+
+**Code pattern:** Service A's `OrderService` reads from the `orders` table. Service B's `AnalyticsService` also reads from and writes analytics metadata to the same `orders` table.
+
+**Assessment:** HIGH | HYG | Service | Loose Coupling (Irreversible + Total)
+
+**Reasoning:** Two services sharing the same database tables creates invisible coupling. Service A's schema migration can break Service B. Service B's writes can corrupt Service A's data. Neither can evolve independently. This triggers both Irreversible (data corruption across boundaries) and Total (schema change cascades to all consumers).
+
+**Boundary — would be MEDIUM / L1 if:** Service B only reads (never writes) to the shared table, and there's a read-replica or view layer between them. The coupling is real but the corruption risk is lower.
+
+### Example S2: Domain logic in controller (HIGH / L1)
+
+**Code pattern:**
+```python
+@app.route("/orders", methods=["POST"])
+def create_order():
+    data = request.json
+    if data["total"] > 1000:
+        data["total"] *= 0.9  # VIP discount
+    if data["shipping"] == "express":
+        data["total"] += 15.00
+    order = Order(**data)
+    db.session.add(order)
+    db.session.commit()
+    send_confirmation_email(order)
+    return jsonify(order.to_dict()), 201
+```
+
+**Assessment:** HIGH | L1 | Service | Separation of Concerns / Testability
+
+**Reasoning:** Business logic (discount calculation, shipping surcharge) lives in the HTTP handler. Testing these rules requires making HTTP requests. The rules can't be reused from a CLI, message handler, or scheduled job. The controller will grow as more business rules are added — it's on the path to becoming a God class.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+@app.route("/orders", methods=["POST"])
+def create_order():
+    data = request.json
+    order = order_service.create_order(data)  # Delegates to domain
+    return jsonify(order.to_dict()), 201
+```
+The controller delegates to a domain service, but the domain service still imports infrastructure (database, email). Separation started but incomplete — a partial L1 improvement.
+
+### Example S3: Missing error hierarchy (MEDIUM / L1)
+
+**Code pattern:**
+```python
+class AppError(Exception):
+    pass
+
+# Every error path uses the same exception type
+raise AppError("Order not found")
+raise AppError("Database connection failed")
+raise AppError("Invalid input: email required")
+raise AppError("Payment service timeout")
+```
+
+**Assessment:** MEDIUM | L1 | Service | Explicit over Implicit
+
+**Reasoning:** All errors use the same type — clients can't distinguish validation errors (don't retry) from infrastructure errors (retry) from business errors (handle differently). The error contract is implicit. This is MEDIUM because the service does signal errors (it's not swallowing them), but operators and clients can't make correct decisions from the error information.
+
+**Boundary — would be HIGH / HYG if:** The generic error type masks data loss — e.g., a write that fails silently returns the same `AppError` as a validation failure, and the caller treats both as "bad input" instead of investigating.
+
+---
+
+## System Level
+
+### Example Y1: Unprotected integration point (HIGH / HYG)
+
+**Code pattern:**
+```python
+def get_user_profile(user_id):
+    # Direct call to downstream service — no timeout, no circuit breaker
+    response = requests.get(f"http://user-service/api/users/{user_id}")
+    return response.json()
+```
+
+**Assessment:** HIGH | HYG | System | Loose Coupling (Total test: yes)
+
+**Reasoning:** No timeout means a hung downstream service blocks the calling thread indefinitely. No circuit breaker means the caller keeps sending requests to a failing service. Under dependency failure, all worker threads can be consumed, making the calling service completely unresponsive. This is the "number-one killer of systems" per Nygard. Total: can render the entire calling service unresponsive.
+
+**Boundary — would be MEDIUM / L1 if:**
+```python
+response = requests.get(
+    f"http://user-service/api/users/{user_id}",
+    timeout=(3, 10)
+)
+```
+Timeout exists but no circuit breaker. The service won't hang indefinitely, but it still sends requests to a failing dependency (wasting resources). L1 gap — basic protection exists but failure isolation doesn't.
+
+### Example Y2: Unbounded result set (HIGH / L1)
+
+**Code pattern:**
+```python
+@app.route("/api/orders")
+def list_orders():
+    orders = order_repository.find_all()  # No limit, no pagination
+    return jsonify([o.to_dict() for o in orders])
+```
+
+**Assessment:** HIGH | L1 | System | Explicit over Implicit
+
+**Reasoning:** With 10 million orders, this serializes all records into memory, saturates the network, and likely times out. Even with fewer records, memory consumption grows linearly with data volume — the endpoint becomes a latent production incident.
+
+**Boundary — would be MEDIUM / L2 if:**
+```python
+orders = order_repository.find_all(limit=1000)
+```
+There's a limit but no pagination, cursor, or streaming. The endpoint is bounded but can't be used for larger result sets. An L2 concern about API design maturity.
+
+### Example Y3: Inconsistent error format across services (LOW / L1)
+
+**Code pattern:**
+Service A returns errors as `{"error": "not found"}`.
+Service B returns errors as `{"code": 404, "message": "Not Found", "details": [...]}`.
+Service C returns errors as plain text: `"Internal Server Error"`.
+
+**Assessment:** LOW | L1 | System | Explicit over Implicit
+
+**Reasoning:** Inconsistent error formats force every consumer to handle each service's error format differently. Error aggregation in monitoring is harder. However, this is LOW severity because each service still communicates errors — the inconsistency is an inconvenience, not a structural risk.
+
+**Boundary — would be MEDIUM / L2 if:** The inconsistency is across the same team's services, indicating no shared error standard. An L2 governance concern.
+
+---
+
+## Landscape Level
+
+### Example L1: Missing ADRs for major decisions (MEDIUM / L2)
+
+**Code pattern:** The codebase uses Kafka for event streaming, PostgreSQL for persistence, and gRPC for inter-service communication. No ADR directory exists. No design docs explain why these technologies were chosen.
+
+**Assessment:** MEDIUM | L2 | Landscape | Explicit over Implicit
+
+**Reasoning:** When the team asks "why Kafka?" or "should we also use Kafka for this new feature?", there's no documented rationale. The decision may have been correct, but without context, every future decision is made without learning from past reasoning. This is an L2 gap — the system works, but governance and institutional knowledge are missing.
+
+**Boundary — would be HIGH / L2 if:** A new team member has already introduced RabbitMQ for a new feature because they didn't know about the Kafka decision. Now the system has two messaging technologies with no documented rationale for either.
+
+### Example L2: Stale tech-spec (MEDIUM / L2)
+
+**Code pattern:** The `tech-spec.md` describes a REST-based architecture. The code has been migrated to gRPC for 3 of 5 services. Two ADRs document the migration, but the tech-spec still describes the original REST architecture.
+
+**Assessment:** MEDIUM | L2 | Landscape | Explicit over Implicit
+
+**Reasoning:** The tech-spec is actively misleading — a new developer reading it will assume REST everywhere. The ADRs document the change but aren't connected to the spec. This is an L2 gap — decisions are documented (ADRs) but the overall design document doesn't reflect them.
+
+**Boundary — would be LOW / L3 if:** The tech-spec is mostly accurate with minor drift in non-critical details (e.g., lists a deprecated endpoint that still exists during sunset).
+
+---
+
+## Cross-level: How the same issue gets different assessments
+
+### Shared database — assessed by different levels
+
+The same shared database might be flagged by:
+
+| Level | Emphasis |
+|-------|----------|
+| **Service** | "This service's domain model is corrupted by another service's schema assumptions" |
+| **System** | "Schema migrations by one service can break the other" (this is the HYG finding) |
+| **Landscape** | "No API boundary exists between these systems — data ownership is ambiguous" |
+
+**During synthesis:** These merge into one finding. The System level's assessment (HYG / Total) takes precedence as the highest severity. The recommendation combines: "Define service APIs for data access (system), separate domain models from shared schema (service), document data ownership in the context map (landscape)."
+
+### Domain logic in controllers — assessed by different levels
+
+The same controller with embedded business logic might be flagged by:
+
+| Level | Emphasis |
+|-------|----------|
+| **Code** | "Class has too many responsibilities — SRP violation" |
+| **Service** | "Domain logic mixed with infrastructure — dependency rule violation" |
+
+**During synthesis:** These merge into one finding. Both are L1, so the combined finding keeps L1. The recommendation combines: "Extract business logic to a domain service (code SRP), ensure the domain service has no infrastructure imports (service dependency rule)."

--- a/spec/arc/framework-map.md
+++ b/spec/arc/framework-map.md
@@ -1,0 +1,128 @@
+# Framework Map — Zoom Levels, Frameworks, and Principles
+
+> How the Architecture domain's frameworks relate to each other. Use this map when writing or reviewing prompts to ensure coverage is complete and analytical lenses are applied correctly.
+
+## The Duality: Principles guide, Erosion threatens
+
+Every design principle has a corresponding erosion pattern — the way architecture degrades when the principle is neglected. When a reviewer identifies an erosion pattern, they should recommend strengthening the corresponding principle.
+
+| Design Principle | Erosion Pattern | Effect of erosion | Where most visible |
+|------------------|----------------|-------------------|-------------------|
+| **Separation of Concerns** | **Mixed responsibilities** | Changes require touching unrelated code. Components grow unbounded. Testing requires standing up the world. | Code (God class), Service (domain logic in controllers) |
+| **Loose Coupling** | **Tight coupling** | Independent deployment impossible. One change ripples across many modules. Circular dependencies prevent extraction. | Code (circular deps), System (shared database), Landscape (coordinated deployments) |
+| **High Cohesion** | **Scattered behaviour** | Related logic spread across modules. Shotgun surgery — one logical change touches many files. Feature envy. | Code (feature envy), Service (service too broad) |
+| **Testability** | **Hidden dependencies** | Can't unit test without infrastructure. Side effects embedded in business logic. Constructor does too much. | Code (untestable code), Service (infrastructure in domain) |
+| **Explicit over Implicit** | **Magic and indirection** | Contracts undocumented. Dependencies invisible. Assumptions buried in code. Newcomers can't understand the system. | Service (missing ACL), System (missing contracts), Landscape (undocumented integration) |
+
+### Using the duality in reviews
+
+When writing a finding:
+1. Identify the **erosion pattern** (how the architecture is degrading)
+2. Check the **design principle** being violated
+3. If the principle is absent or insufficient, that's the finding
+4. The recommendation should describe the principle to strengthen, not a specific technique
+
+Example:
+- Erosion: Tight coupling (Service A imports Service B's internal models)
+- Principle needed: Loose coupling (depend on published contracts, not internals)
+- Finding: "Service A directly imports Service B's database models, creating deployment coupling"
+- Recommendation: "Introduce a translation boundary — consume Service B's published API contract rather than its internal models"
+
+## Zoom Level Framework Sources
+
+Each zoom level draws its analytical lens from specific framework sources. This is not exclusive — any framework insight can appear at any level — but these are the primary sources each subagent should apply.
+
+### Code Level
+
+**Primary question:** Is the code well-structured?
+
+| Framework | What it provides | How it's applied |
+|-----------|-----------------|-----------------|
+| **SOLID** (Martin) | Five principles for class/module design | Review checklist: SRP, OCP, LSP, ISP, DIP |
+| **DDD Tactical** (Evans) | Patterns for modelling domain concepts | Review checklist: Entities, Value Objects, Aggregates, Repositories, Domain Events |
+| **Modern SE** (Farley) | Complexity management through testability | Review checklist: testability, cyclomatic complexity, cohesion, coupling, naming |
+
+### Service Level
+
+**Primary question:** Is the service well-designed?
+
+| Framework | What it provides | How it's applied |
+|-----------|-----------------|-----------------|
+| **DDD Strategic** (Evans) | Bounded contexts, model integrity, translation | Review checklist: context boundary, ubiquitous language, model integrity, ACLs |
+| **Clean Architecture** (Martin) | Dependency rule, layering, ports & adapters | Review checklist: dependency direction, separation of concerns, CQRS |
+| **Modern SE** (Farley) | Independent deployability, configuration | Review checklist: deployment independence, health checks, graceful lifecycle |
+
+### System Level
+
+**Primary question:** Do services work well together?
+
+| Framework | What it provides | How it's applied |
+|-----------|-----------------|-----------------|
+| **Release It!** (Nygard) | Stability patterns and anti-patterns | Review checklist: circuit breaker, bulkhead, timeout, shed load, backpressure, fail fast, governor |
+| **EIP** (Hohpe & Woolf) | Communication style selection | Review checklist: sync vs async, event vs command, idempotency |
+| **Postel's Law** | Tolerant communication | Review checklist: backward compatibility, tolerant reader |
+
+### Landscape Level
+
+**Primary question:** Does it fit the wider ecosystem?
+
+| Framework | What it provides | How it's applied |
+|-----------|-----------------|-----------------|
+| **EIP** (Hohpe & Woolf) | Integration patterns for distributed systems | Review checklist: message design, routing, transformation, dead letters, idempotent consumers |
+| **DDD Context Maps** (Evans) | Cross-boundary relationship types | Review checklist: context map, relationship types (partnership, customer-supplier, conformist, ACL, open host, published language) |
+| **ADR Pattern** (Nygard, Keeling) | Decision documentation | Review checklist: ADRs, tech-spec traceability, decision freshness |
+| **Evolutionary Architecture** (Ford, Parsons, Kua) | Fitness functions, incremental change | Review checklist: fitness functions, backward compatibility, deprecation, migration |
+
+## Coverage Matrix
+
+This matrix shows which design principles are the primary concern at each zoom level. Use it to verify that prompt changes don't create coverage gaps.
+
+| | Separation of Concerns | Loose Coupling | High Cohesion | Testability | Explicit over Implicit |
+|---|---|---|---|---|---|
+| **Code** | Primary | Primary | Primary | Primary | Secondary |
+| **Service** | Primary | Primary | Secondary | Primary | Primary |
+| **System** | Secondary | Primary | - | - | Primary |
+| **Landscape** | - | Primary | - | - | Primary |
+
+**Key:** Primary = core focus area for this zoom level. Secondary = reviewed but not the primary lens. `-` = not a focus area (may still be flagged if found).
+
+## Framework-to-Zoom-Level Coverage Matrix
+
+This matrix shows which frameworks are the primary analytical lens at each zoom level.
+
+| | SOLID | DDD Tactical | DDD Strategic | Release It! | EIP | Modern SE | ADR/Governance |
+|---|---|---|---|---|---|---|---|
+| **Code** | Primary | Primary | - | - | - | Primary | - |
+| **Service** | - | Secondary | Primary | - | - | Primary | - |
+| **System** | - | - | Secondary | Primary | Secondary | - | - |
+| **Landscape** | - | - | Primary | - | Primary | - | Primary |
+
+**Key:** Primary = core analytical lens for this level. Secondary = relevant but not the primary focus. `-` = not applicable at this level.
+
+## Inter-Level Handoffs
+
+When a finding spans zoom levels, the subagent that discovers it should flag it in their own level's terms. The synthesis step deduplicates across levels.
+
+Common handoff scenarios:
+
+| Scenario | Discovered by | Also relevant to |
+|----------|---------------|------------------|
+| A class violates SRP AND the service has mixed bounded contexts | Code (God class) | Service (service too broad) |
+| A service depends on another's internals AND there's no contract | Service (missing ACL) | System (data coupling) |
+| Circular dependency between classes creates deployment coupling | Code (circular deps) | System (cascading failure risk) |
+| Shared database at code level AND no API boundary at system level | Service (shared database) | System + Landscape (integration point) |
+| Missing error model design AND missing error classification | Service (error hierarchy) | System (inconsistent error responses) |
+| Domain logic in controllers AND missing testability | Code (testability) | Service (domain logic in controllers) |
+
+## Boundary with Other Domains
+
+The Architecture domain focuses on **design-time structure**. When a finding could belong to multiple domains, use this boundary guide:
+
+| Finding type | Architecture owns | Other domain owns |
+|-------------|-------------------|-------------------|
+| Circuit breaker | "Is this the right pattern for this integration point?" | SRE: "Is it configured with correct thresholds and monitored?" |
+| Error handling | "Is the error model well-designed? (hierarchy, classification, propagation)" | SRE: "Can operators diagnose from errors at 3am?" |
+| Coupling | "Is the dependency structurally appropriate?" | SRE: "Does it cause cascading failure at runtime?" |
+| Deployability | "Is it independently deployable by design?" | SRE: "Can it be safely rolled out with rollback?" |
+| Data model | "Are bounded contexts correctly separated?" | Data: "Are schema contracts defined and quality monitored?" |
+| Access control | "Is the authorization model well-designed?" | Security: "Can an attacker bypass the authorization checks?" |

--- a/spec/arc/glossary.md
+++ b/spec/arc/glossary.md
@@ -1,0 +1,207 @@
+# Glossary — Architecture Domain
+
+> Canonical definitions for all terms, frameworks, and acronyms used in the Architecture review domain. When writing or modifying prompts, use these definitions exactly.
+
+## Frameworks
+
+### C4-Inspired Zoom Levels
+
+The structural framework that organises the Architecture review into four nested scopes, each with a dedicated subagent. Inspired by Simon Brown's C4 Model but adapted for code review rather than diagramming.
+
+Origin: C4 Model (Simon Brown), adapted by the donkey-dev project for review decomposition.
+
+| Zoom Level | Scope | Key Question |
+|------------|-------|-------------|
+| **Code** | Classes, functions, modules | Is the code well-structured? |
+| **Service** | A deployable unit (one service/app) | Is the service well-designed? |
+| **System** | Multiple services interacting | Do services work well together? |
+| **Landscape** | Multiple systems / ecosystem | Does it fit the wider ecosystem? |
+
+### Domain-Driven Design (DDD)
+
+Eric Evans' framework for managing domain complexity through bounded contexts (strategic) and tactical patterns (entities, value objects, aggregates). Applied at the Code and Service zoom levels primarily, with Context Maps at the Landscape level.
+
+Origin: Eric Evans, *Domain-Driven Design*, 2003.
+
+### Release It!
+
+Michael Nygard's stability patterns and anti-patterns for production-ready software. Provides the analytical lens for the System zoom level — how services protect themselves from failure at integration points.
+
+Origin: Michael T. Nygard, *Release It!*, 2nd Edition, 2018.
+
+### Enterprise Integration Patterns (EIP)
+
+Hohpe & Woolf's catalogue of messaging patterns for connecting distributed systems. Applied at the Landscape zoom level — how systems integrate, route messages, and handle integration failures.
+
+Origin: Gregor Hohpe & Bobby Woolf, *Enterprise Integration Patterns*, 2003.
+
+### Modern Software Engineering
+
+Dave Farley's framework for managing complexity through testability and deployability. Applied as cross-cutting principles at all zoom levels.
+
+Origin: Dave Farley, *Modern Software Engineering*, 2021.
+
+## Zoom Level Definitions
+
+Each zoom level maps to one subagent and one prompt checklist.
+
+### Code Level
+
+**Scope:** Classes, functions, modules — the innermost structural units.
+
+**Primary concerns:** SOLID principles, DDD tactical patterns (Entities, Value Objects, Aggregates), code quality (testability, complexity, cohesion, coupling, naming).
+
+**Key question:** "Is the code well-structured?"
+
+**Framework sources:** SOLID (Martin), DDD Tactical (Evans), Modern Software Engineering (Farley).
+
+### Service Level
+
+**Scope:** A deployable unit — one service, application, or independently-deployable component.
+
+**Primary concerns:** Bounded context alignment, architecture & layering (dependency rule, ports & adapters), deployability, error model design.
+
+**Key question:** "Is the service well-designed?"
+
+**Framework sources:** DDD Strategic (Evans), Clean Architecture (Martin), Modern Software Engineering (Farley).
+
+### System Level
+
+**Scope:** Multiple services interacting — the inter-service boundary.
+
+**Primary concerns:** Stability patterns (circuit breaker, bulkhead, timeout, shed load, backpressure, fail fast, governor), API contracts & communication, coupling & cohesion at the service level.
+
+**Key question:** "Do services work well together?"
+
+**Framework sources:** Release It! (Nygard), EIP basics (Hohpe & Woolf).
+
+### Landscape Level
+
+**Scope:** Multiple systems, the wider ecosystem — system-of-systems.
+
+**Primary concerns:** DDD context maps, Enterprise Integration Patterns (message design, routing, transformation, error handling), architectural governance (ADRs, fitness functions, standards), design documentation traceability, evolution & change management.
+
+**Key question:** "Does it fit the wider ecosystem?"
+
+**Framework sources:** EIP (Hohpe & Woolf), DDD Context Maps (Evans), ADR pattern (Nygard, Keeling).
+
+## Design Principle Terminology
+
+### Domain-Driven Design Terms
+
+| Term | Definition | Where evaluated |
+|------|-----------|-----------------|
+| **Bounded Context** | A domain boundary where a particular model applies; crossing requires explicit mapping. | Service, System, Landscape |
+| **Ubiquitous Language** | Shared vocabulary between code and domain experts within a bounded context. | Code, Service |
+| **Aggregate** | A cluster of domain objects treated as a single transactional unit with a root entity. | Code, Service |
+| **Value Object** | An immutable object defined by its attributes, not by identity (e.g., Money, Address). | Code |
+| **Domain Event** | A record of something significant that happened in the domain. | Code, Landscape |
+| **Anti-Corruption Layer (ACL)** | A translation layer that prevents one system's model from leaking into another. | Service, System, Landscape |
+| **Context Map** | A diagram showing relationships and integration patterns between bounded contexts. | Landscape |
+| **Published Language** | A shared interchange format for cross-context communication. | Landscape |
+
+### Stability Terms (Release It!)
+
+| Term | Definition | Where evaluated |
+|------|-----------|-----------------|
+| **Circuit Breaker** | A pattern that stops calling a failing dependency after a threshold, allowing recovery. | System |
+| **Bulkhead** | Compartmentalization to isolate failures (separate pools per dependency). | System |
+| **Timeout** | Explicit time bound on inter-service calls. | System |
+| **Shed Load** | Rejecting excess work to protect system stability under overload. | System |
+| **Backpressure** | Mechanism for consumers to signal producers to slow down. | System |
+| **Governor** | A rate-limiting mechanism controlling execution speed. | System |
+| **Dogpile** | Thundering herd problem when many clients simultaneously retry or recache. | System |
+| **Fail Fast** | Services reject known-bad requests immediately, refuse traffic when not ready. | System |
+
+### Integration Terms (EIP)
+
+| Term | Definition | Where evaluated |
+|------|-----------|-----------------|
+| **Message Channel** | A named conduit for moving messages between systems. | Landscape |
+| **Message Router** | Logic determining which channel a message should follow. | Landscape |
+| **Message Transformer** | Logic converting messages between formats. | Landscape |
+| **Dead Letter Channel** | A destination for messages that cannot be processed. | Landscape |
+| **Idempotent Consumer** | A consumer that safely handles duplicate messages. | Landscape |
+
+### Governance Terms
+
+| Term | Definition | Where evaluated |
+|------|-----------|-----------------|
+| **ADR** | Architecture Decision Record — documents what was decided, why, and the consequences. | Landscape |
+| **Fitness Function** | An automated test that validates an architectural characteristic is preserved. | Landscape |
+| **Strangler Fig** | A migration pattern where new code gradually replaces old, running in parallel. | Landscape |
+
+### Cross-Cutting Principles
+
+These principles apply at all zoom levels and should be evaluated everywhere:
+
+| Principle | Definition |
+|-----------|-----------|
+| **Separation of Concerns** | Each component should have a single, well-defined responsibility. |
+| **Loose Coupling** | Minimize dependencies between components; depend on abstractions. |
+| **High Cohesion** | Group related behavior together; keep unrelated behavior apart. |
+| **Testability** | Design so that behavior can be verified automatically. |
+| **Explicit over Implicit** | Make dependencies, contracts, and assumptions visible. |
+
+## Maturity Model
+
+### Hygiene Gate
+
+A promotion gate that overrides maturity levels. Any finding at any level is promoted to `HYG` if it passes any of these three consequence-severity tests:
+
+| Test | Question | Architecture examples |
+|------|----------|----------------------|
+| **Irreversible** | If this goes wrong, can the damage be undone? | Two services writing directly to the same database tables (corrupted data). Circular dependency chain where extracting the cycle requires rewriting both modules. |
+| **Total** | Can this take down the entire service or cascade beyond its boundary? | Synchronous circular dependency chain where one failure cascades to all participants. Deployment requires all services released simultaneously (shared fate). |
+| **Regulated** | Does this violate a legal or compliance obligation? | PII exposed through leaky abstraction in a public API response. System boundary that violates data residency requirements. |
+
+Any "yes" to any test = `HYG`. The Hygiene flag trumps all maturity levels.
+
+### Maturity Levels
+
+Levels are cumulative. Each requires the previous. See `maturity-criteria.md` for detailed criteria with thresholds.
+
+| Level | Name | One-line description |
+|-------|------|---------------------|
+| **L1** | Foundations | The basics are in place. The system has clear structure and can be understood and tested. |
+| **L2** | Hardening | Architecturally mature. Integration contracts, design rationale, and failure containment exist. |
+| **L3** | Excellence | Best-in-class. Architecture is governed, validated automatically, and evolves incrementally. |
+
+### Severity Levels
+
+| Level | Structural impact | Merge decision |
+|-------|-------------------|----------------|
+| **HIGH** | Fundamental design flaw — systemic risk, shared mutable state, circular dependencies | Must fix before merge |
+| **MEDIUM** | Design smell — principle violation, leaky abstraction, missing documentation | May require follow-up ticket |
+| **LOW** | Style improvement — minor naming, minor restructuring | Nice to have |
+
+Severity measures **structural consequence**, not implementation difficulty.
+
+### Status Indicators
+
+Used in maturity assessment tables:
+
+| Indicator | Meaning |
+|-----------|---------|
+| `pass` | All criteria at this level are met |
+| `partial` | Some criteria met, some not |
+| `fail` | No criteria met, or critical criteria missing |
+| `locked` | Previous level not achieved; this level cannot be assessed |
+
+## Orchestration Terms
+
+| Term | Definition |
+|------|-----------|
+| **Zoom Level** | One of the 4 C4-inspired scopes (Code, Service, System, Landscape). Each zoom level has one subagent. |
+| **Subagent** | A specialised reviewer that analyses code against one zoom level's checklist. Runs in parallel with the other 3. |
+| **Skill orchestrator** | The `/review-arch` skill that dispatches subagents, collects results, deduplicates, and synthesises the final report. |
+| **Synthesis** | The process of merging 4 subagent reports into one consolidated maturity assessment. |
+| **Deduplication** | When two subagents flag the same file:line, merging into one finding with the highest severity and most restrictive maturity tag. |
+
+## Output Terms
+
+| Term | Definition |
+|------|-----------|
+| **Finding** | A single identified issue: severity, maturity level, zoom level, file location, description, and recommendation. |
+| **Maturity assessment** | Per-criterion evaluation (met/not met/partially met) for each maturity level. |
+| **Immediate action** | The single most important thing to fix. Hygiene failure if any exist, otherwise the top finding from the next achievable level. |

--- a/spec/arc/maturity-criteria.md
+++ b/spec/arc/maturity-criteria.md
@@ -1,0 +1,315 @@
+# Maturity Criteria — Architecture Domain
+
+> Detailed criteria for each maturity level with defined "sufficient" thresholds. Use this when assessing criteria as Met / Not met / Partially met.
+
+## Hygiene Gate
+
+The Hygiene gate is not a maturity level — it is a promotion gate. Any finding at any level that passes any of the three tests is promoted to `HYG`.
+
+### Test 1: Irreversible
+
+**Question:** If this goes wrong, can the damage be undone?
+
+**Threshold:** If a structural flaw would produce damage that requires more than a rollback/restart to fix — e.g., corrupted data across service boundaries, merged data that can't be unmerged, shared state that multiple services have written to inconsistently — this is irreversible.
+
+**Architecture examples that trigger this test:**
+- Two services writing directly to the same database tables — data corruption from conflicting writes can't be unwound without understanding both services' write patterns
+- Circular dependency between modules that has been accumulated over months — extracting it requires rewriting both modules and all their consumers
+- Schema changes deployed to a shared database that other services depend on — rolled-back code still encounters the new schema
+
+**Architecture examples that do NOT trigger this test:**
+- Missing abstraction layer (bad design but fixable without data risk)
+- Inconsistent naming (confusing but not damaging)
+- Missing ADRs (knowledge gap but no corruption)
+
+### Test 2: Total
+
+**Question:** Can this take down the entire service or cascade beyond its boundary?
+
+**Threshold:** If a structural flaw can cause one component's failure to propagate beyond its boundary — taking down the entire service, blocking all deployments, or cascading to other services — this is total.
+
+**Architecture examples that trigger this test:**
+- Synchronous circular dependency chain where one service's failure cascades to all participants in the cycle
+- Deployment coupling — all services must be deployed simultaneously, so one deployment failure blocks all
+- Shared database across services — one service's migration breaks all consumers
+- Distributed monolith — services that can't function independently, so one outage brings down all
+
+**Architecture examples that do NOT trigger this test:**
+- A God class within a single service (contained to one deployment unit)
+- Missing bounded context boundary (poor cohesion but failures are contained)
+- Anemic domain model (bad design but doesn't cause cascading failure)
+
+### Test 3: Regulated
+
+**Question:** Does this violate a legal or compliance obligation?
+
+**Threshold:** If the architectural design would cause a breach of data protection law, financial regulation, accessibility requirements, or other legal obligations, this is regulated.
+
+**Architecture examples that trigger this test:**
+- PII leaking through a missing Anti-Corruption Layer into a public API response
+- Data residency requirements violated by architectural boundary placement (e.g., EU user data processed by a US-only service)
+- Financial calculation logic using floating-point arithmetic for money (regulatory accuracy requirements)
+
+**Architecture examples that do NOT trigger this test:**
+- Missing ADRs (governance gap, not regulatory)
+- No fitness functions (quality gap, not compliance)
+- Inconsistent API styles across services (style issue, not regulatory)
+
+---
+
+## Level 1 — Foundations
+
+**Overall intent:** The basics are in place. The system has clear structure and can be understood and tested. A new developer can find module boundaries and understand dependencies.
+
+### Criterion 1.1: Module boundaries are explicit with defined public interfaces
+
+**Definition:** Modules, packages, or services have clear boundaries with intentional public APIs. Internal implementation details are not exposed to consumers.
+
+**Met (sufficient):**
+- Modules have defined public interfaces (exports, public methods, API contracts)
+- Internal implementation details are not accessible from outside the module
+- It is clear from the code structure which parts are public and which are internal
+- New functionality has a clear "home" — you know which module it belongs to
+
+**Partially met:**
+- Some modules have clear boundaries, others are loosely defined
+- Public interfaces exist but internal details leak (e.g., domain objects expose ORM annotations)
+- Module boundaries are implicit (based on convention, not enforced)
+
+**Not met:**
+- No clear module boundaries — classes and functions are organised by technical layer only (all controllers together, all models together)
+- Everything is public — any module can import anything from any other module
+- Module placement is arbitrary — similar concepts live in different modules
+
+### Criterion 1.2: Dependencies flow inward
+
+**Definition:** Infrastructure (database, HTTP, filesystem) depends on the domain — not the reverse. Business logic does not import infrastructure frameworks.
+
+**Met (sufficient):**
+- Domain/business logic has no imports from infrastructure frameworks (ORM, HTTP, messaging)
+- Infrastructure code implements interfaces defined in the domain layer
+- The dependency graph shows: infrastructure → application → domain (never domain → infrastructure)
+- Changing the database or HTTP framework would not require modifying domain logic
+
+**Partially met:**
+- Most domain logic is infrastructure-free, but some domain objects have ORM annotations or HTTP concerns
+- The general direction is correct but there are exceptions (some domain classes import utility functions from infrastructure packages)
+
+**Not met:**
+- Domain classes inherit from ORM base classes or use ORM annotations
+- Business logic directly calls database queries, HTTP endpoints, or filesystem operations
+- No distinction between domain and infrastructure layers
+
+### Criterion 1.3: Components can be tested in isolation
+
+**Definition:** Business logic can be unit tested without standing up infrastructure (database, network, filesystem, message broker).
+
+**Met (sufficient):**
+- Dependencies are injectable (constructor injection, parameter injection)
+- Side effects are isolated behind interfaces that can be substituted in tests
+- Unit tests exist that verify business logic without infrastructure
+- Test files exist alongside or near the code they test
+
+**Partially met:**
+- Some components are testable in isolation, others require infrastructure
+- Dependencies are injectable but no tests exercise this capability
+- Tests exist but all require a running database or service
+
+**Not met:**
+- Dependencies are constructed internally (hidden dependencies)
+- Business logic can only be tested through integration tests
+- No tests exist, or tests only verify infrastructure wiring
+
+### Criterion 1.4: No circular dependencies between modules
+
+**Definition:** The dependency graph between modules/packages is a directed acyclic graph (DAG). No module depends on another module that depends back on it (directly or transitively).
+
+**Met (sufficient):**
+- No circular imports between modules or packages
+- The dependency graph is a clean tree or DAG
+- Module dependencies are explicitly declared (imports, package references)
+
+**Partially met:**
+- No direct circular dependencies, but transitive cycles exist through shared modules
+- Circular dependencies exist but are contained within a single bounded context
+
+**Not met:**
+- Direct circular dependencies between modules (A imports B, B imports A)
+- Circular dependency chains spanning multiple modules
+- Import order matters (fragile initialisation)
+
+---
+
+## Level 2 — Hardening
+
+**Overall intent:** Architecturally mature. The system has explicit contracts, documented design rationale, and failure containment at integration boundaries. Teams can reason about the system's design without reading all the code.
+
+**Prerequisite:** All L1 criteria must be met.
+
+### Criterion 2.1: Integration contracts are defined between boundaries
+
+**Definition:** Services and modules that communicate have explicit, versioned contracts — not just "it calls that endpoint."
+
+**Met (sufficient):**
+- API contracts exist (OpenAPI, Protobuf, GraphQL schema, AsyncAPI, or equivalent)
+- Contracts are stored in version control
+- Contracts distinguish between stable/public interfaces and internal/unstable ones
+- Breaking changes are detectable (contract tests, schema validation, or equivalent)
+
+**Partially met:**
+- Some contracts are formal, others are implicit (known only through code inspection)
+- Contracts exist but aren't versioned or tested
+- Contracts exist but don't cover all integration points
+
+**Not met:**
+- No formal contracts — integration is through code inspection and tribal knowledge
+- Contract changes are discovered at runtime (production errors)
+- No distinction between public/stable and internal/experimental APIs
+
+### Criterion 2.2: Design decisions are documented with rationale and trade-offs
+
+**Definition:** Significant architectural decisions are recorded in a retrievable format — ADRs, design docs, tech-specs, or equivalent — including the why, not just the what.
+
+**Met (sufficient):**
+- ADRs or equivalent exist for major technology choices (language, framework, database, messaging)
+- Each record includes context (why the decision was needed), decision (what was chosen), and consequences (trade-offs accepted)
+- Records are stored in version control alongside the code
+- Records are current — recent decisions are documented, not just historical ones
+
+**Partially met:**
+- Some decisions are documented but major ones are missing
+- Documentation exists but lacks rationale ("we chose PostgreSQL" without explaining why)
+- Records exist but are stale — the system has evolved beyond what's documented
+
+**Not met:**
+- No architectural decision documentation
+- Decisions exist only in people's heads or buried in Slack/email threads
+- A tech-spec exists but hasn't been updated in more than 6 months and doesn't match the code
+
+### Criterion 2.3: Failure at integration points is contained, not propagated
+
+**Definition:** When an external dependency fails, the failure does not cascade to unrelated functionality. Some form of structural isolation exists at the design level.
+
+**Met (sufficient):**
+- Integration points have explicit failure handling (not just catch-all exception handlers)
+- Non-critical dependencies are structurally separated from critical paths (different modules, different call paths)
+- The design includes degradation options — reduced functionality rather than total failure
+- Failure domains are intentional and documented
+
+**Partially met:**
+- Some integration points have failure isolation, others don't
+- Failure handling exists but all failures are treated the same (no critical vs non-critical distinction)
+- Degradation exists by accident (catch blocks that return null) rather than by design
+
+**Not met:**
+- No structural failure isolation — all dependencies are called in the same code path
+- One dependency failure causes the entire service to fail
+- No distinction between critical and non-critical dependencies in the code structure
+
+### Criterion 2.4: Bounded contexts are explicit and internally consistent
+
+**Definition:** Services or modules aligned to domain concepts have internally consistent models that don't leak across boundaries.
+
+**Met (sufficient):**
+- Each service or major module serves a single cohesive domain concept
+- Domain terminology is consistent within each context (ubiquitous language)
+- Cross-context communication uses explicit translation (ACLs, mapping layers)
+- External models are not used directly in domain logic
+
+**Partially met:**
+- Most services have clear domain alignment, but some serve multiple contexts
+- Translation layers exist at some boundaries but not all
+- Domain terminology is mostly consistent but has some confusing overlap
+
+**Not met:**
+- Services serve multiple unrelated domain concepts
+- External DTOs are used throughout domain logic
+- The same term means different things in different parts of the codebase with no explicit mapping
+
+---
+
+## Level 3 — Excellence
+
+**Overall intent:** Best-in-class. Architecture is actively governed, constraints are validated automatically, and the system can evolve incrementally without coordinated deployment.
+
+**Prerequisite:** All L2 criteria must be met.
+
+### Criterion 3.1: Architectural constraints are validated automatically in CI
+
+**Definition:** Fitness functions or equivalent automated tests verify that architectural rules are preserved across changes.
+
+**Met (sufficient):**
+- Automated tests enforce dependency direction (no domain → infrastructure imports)
+- Circular dependency detection runs in CI
+- API compatibility checks detect breaking changes before merge
+- At least one fitness function exists for a non-trivial architectural characteristic
+
+**Partially met:**
+- Some architectural tests exist but don't cover the most important constraints
+- Tests exist but run manually, not in CI
+- Dependency checks exist but only at the package level, not the module level
+
+**Not met:**
+- No automated architectural tests
+- Architectural rules exist on paper but are not enforced
+- CI runs only functional tests, no structural validation
+
+### Criterion 3.2: Cross-boundary relationships are documented and kept current
+
+**Definition:** A context map or equivalent documentation shows how bounded contexts relate, with explicit relationship types (partnership, customer-supplier, conformist, ACL, etc.).
+
+**Met (sufficient):**
+- A context map (visual or structured) exists showing all bounded contexts and their relationships
+- Relationship types are explicit (not just "A calls B" but "A is a customer-supplier to B")
+- The map is maintained — it reflects the current state of the system, not a historical snapshot
+- Changes to cross-boundary relationships trigger documentation updates
+
+**Partially met:**
+- A context map exists but is stale or incomplete
+- Relationships are documented but types are implicit
+- Some cross-boundary relationships are documented, others are not
+
+**Not met:**
+- No context map exists
+- Cross-boundary relationships are discovered only through code inspection
+- Documentation exists but describes a previous version of the system
+
+### Criterion 3.3: Changes can be made incrementally without coordinated deployment
+
+**Definition:** Services can be deployed independently. Breaking changes use incremental strategies (expand-contract, strangler fig, feature flags).
+
+**Met (sufficient):**
+- Services can be deployed in any order without coordination
+- Breaking changes follow expand-contract (add new, migrate, remove old)
+- Feature flags or equivalent exist for significant behaviour changes
+- Database migrations are backward-compatible (add-before-remove)
+
+**Partially met:**
+- Most services deploy independently but some still require coordination
+- Expand-contract is used sometimes but not consistently
+- Feature flags exist for some features but not standard practice
+
+**Not met:**
+- Deployment requires coordinating multiple services
+- Breaking changes are deployed directly
+- Database migrations require downtime or break backward compatibility
+
+### Criterion 3.4: Evolution strategy exists for major changes
+
+**Definition:** The team has patterns and infrastructure for managing large-scale architectural evolution without big-bang rewrites.
+
+**Met (sufficient):**
+- Migration patterns are documented and used (strangler fig, parallel run, branch by abstraction)
+- Technology choices are deliberate and documented (technology radar, ADRs for new adoptions)
+- Deprecation process exists — old interfaces are sunset with timelines and migration guides
+- The number of technologies solving the same problem is bounded (not 3 different messaging systems)
+
+**Partially met:**
+- Some migration patterns are used ad hoc but no standard approach exists
+- Technology choices are mostly deliberate but some are inherited and undocumented
+- Deprecation happens but without formal timelines or consumer communication
+
+**Not met:**
+- No migration patterns — changes are big-bang rewrites
+- Technology choices are ad hoc — new technologies adopted without evaluation
+- No deprecation process — old interfaces persist indefinitely alongside new ones

--- a/spec/arc/references.md
+++ b/spec/arc/references.md
@@ -1,0 +1,181 @@
+# References — Architecture Domain
+
+> Source attribution for all frameworks, concepts, and terminology used in the Architecture review domain. Cite these when asked about the origin of a concept. Update this file when new sources are introduced.
+
+## Framework Origins
+
+### C4-Inspired Zoom Levels (Code, Service, System, Landscape)
+
+**Origin:** Simon Brown, *The C4 Model for Visualising Software Architecture*
+**URL:** https://c4model.com/
+**Status:** Adapted as the structural backbone of the Architecture review domain. The C4 Model defines four abstraction levels for diagramming (Context, Container, Component, Code). The Architecture review reinterprets these as four zoom levels for code review, with different names and scopes: Code (≈ Code/Component), Service (≈ Container), System (≈ Container interactions), Landscape (≈ Context/System of Systems).
+
+**Key design decision (PR #7):** The level was named "Landscape" rather than "Enterprise" to avoid enterprise baggage — the framework works for startups, scale-ups, and enterprises equally.
+
+**How it's used:** Organises the Architecture review into 4 zoom levels, each with a dedicated subagent. Every Architecture review runs all 4 zoom levels in parallel.
+
+### SOLID Principles
+
+**Origin:** Robert C. Martin (Uncle Bob)
+**Publications:**
+- *Agile Software Development, Principles, Patterns, and Practices*, 2002
+- *Clean Architecture*, 2017
+
+**Status:** Applied at the Code zoom level as the primary structural quality lens.
+
+**Principles:**
+- **S**ingle Responsibility Principle (SRP) — one reason to change
+- **O**pen/Closed Principle (OCP) — open for extension, closed for modification
+- **L**iskov Substitution Principle (LSP) — subtypes honour base type contracts
+- **I**nterface Segregation Principle (ISP) — clients shouldn't depend on methods they don't use
+- **D**ependency Inversion Principle (DIP) — depend on abstractions, not concretions
+
+### Maturity Model (Hygiene, L1, L2, L3)
+
+**Origin:** Original to this project.
+**Design history:**
+- PR #13/Issue #13: Initial maturity scoring concept — hygiene factors vs aspirational targets
+- PR #18: Added domain-specific maturity criteria to all 4 review domains
+- PR #19: Rewrote as universal Hygiene gate (Irreversible/Total/Regulated) with outcome-based levels. Removed technique names from criteria.
+
+**Key design decision (PR #19):** The Hygiene gate uses consequence-severity tests, not domain-specific checklists. This ensures the same escalation logic across Architecture, SRE, Security, and Data domains.
+
+## Books and Publications
+
+### Domain-Driven Design
+
+**Author:** Eric Evans
+**Published:** 2003, Addison-Wesley
+**ISBN:** 978-0321125217
+**Relevance:** Foundational source for bounded contexts, ubiquitous language, aggregates, value objects, domain events, anti-corruption layers, and context maps. The most heavily-referenced book across the Architecture domain — concepts appear at Code, Service, and Landscape zoom levels.
+**Specific concepts referenced:**
+- Bounded Context (Service, Landscape)
+- Ubiquitous Language (Code, Service)
+- Aggregate (Code)
+- Value Object (Code)
+- Entity (Code)
+- Domain Event (Code, Landscape)
+- Anti-Corruption Layer (Service, System, Landscape)
+- Context Map (Landscape)
+- Published Language (Landscape)
+- Customer-Supplier, Conformist, Partnership relationships (Landscape)
+
+### Modern Software Engineering
+
+**Author:** Dave Farley
+**Published:** 2021, Addison-Wesley
+**ISBN:** 978-0137314911
+**Relevance:** Provides the testability and deployability lens applied at all zoom levels. Key principle: complexity is the root cause of most software failures; testability and deployability are the primary tools for managing it.
+**Specific concepts referenced:**
+- Testability as a design driver (Code, Service)
+- Independent deployability (Service)
+- Managing complexity through modularity (Code, Service)
+- Verification at multiple levels — unit, integration, acceptance (Code)
+- Cyclomatic complexity management (Code)
+
+### Release It! (2nd Edition)
+
+**Author:** Michael T. Nygard
+**Published:** 2018, Pragmatic Bookshelf
+**ISBN:** 978-1680502398
+**Relevance:** Provides the stability patterns and anti-patterns applied at the System zoom level. The famous quote "Integration points are the number-one killer of systems" drives the System level's focus on protected integration points.
+**Specific patterns referenced:**
+- Circuit Breaker (System — Chapter 5)
+- Bulkhead (System — Chapter 5)
+- Timeout (System — Chapter 5)
+- Shed Load (System — Chapter 5)
+- Backpressure (System — Chapter 5)
+- Fail Fast (System — Chapter 5)
+- Governor (System — Chapter 5)
+- Dogpile / Thundering Herd (System — Chapter 5)
+- Integration Point as the #1 killer (System — Chapter 4)
+- Cascading Failures (System — Chapter 4)
+
+### Enterprise Integration Patterns
+
+**Authors:** Gregor Hohpe, Bobby Woolf
+**Published:** 2003, Addison-Wesley
+**ISBN:** 978-0321200686
+**Relevance:** Provides the integration pattern vocabulary applied at the Landscape zoom level and partially at the System level. The catalogue of messaging patterns (channels, routers, transformers) informs the Landscape checklist.
+**Specific patterns referenced:**
+- Message Channel (Landscape)
+- Message Router / Content-Based Router (Landscape)
+- Message Transformer (Landscape)
+- Dead Letter Channel (Landscape)
+- Idempotent Consumer (Landscape, System)
+- Message Design: Commands, Events, Documents (Landscape)
+- Splitter/Aggregator (Landscape)
+- Integration Styles: File Transfer, Shared Database, RPC, Messaging (Landscape)
+
+### Clean Architecture
+
+**Author:** Robert C. Martin
+**Published:** 2017, Prentice Hall
+**ISBN:** 978-0134494166
+**Relevance:** Provides the dependency rule and layering concepts applied at the Service zoom level. The core principle: dependencies should point inward — outer layers depend on inner layers, never the reverse.
+**Specific concepts referenced:**
+- Dependency Rule (Service)
+- Ports & Adapters / Hexagonal Architecture (Service)
+- Use Cases / Application layer (Service)
+- Entities / Domain layer (Service)
+
+### Building Evolutionary Architectures
+
+**Authors:** Neal Ford, Rebecca Parsons, Patrick Kua
+**Published:** 2017, O'Reilly Media
+**ISBN:** 978-1491986363
+**Relevance:** Provides the fitness function and evolutionary architecture concepts applied at the Landscape zoom level.
+**Specific concepts referenced:**
+- Fitness Functions (Landscape)
+- Evolutionary Architecture (Landscape)
+- Incremental Change (Landscape, L3 criteria)
+
+## Standards and Conventions
+
+### Postel's Law (Robustness Principle)
+
+**Origin:** Jon Postel, RFC 761 (1980)
+**Statement:** "Be conservative in what you send, be liberal in what you accept."
+**Relevance:** Applied at the System zoom level for API backward compatibility and the Tolerant Reader pattern. Services should tolerate unknown fields and unexpected values from peers.
+
+### Architecture Decision Records (ADRs)
+
+**Origin:** Michael Nygard, blog post "Documenting Architecture Decisions" (2011)
+**Extended by:** Joel Parker Henderson (ADR GitHub organisation), Andrew Harmel-Law
+**Relevance:** Applied at the Landscape zoom level. ADRs are the standard format for documenting architectural decisions with context, decision, and consequences.
+**Template:** Context → Decision → Consequences → Status (Proposed/Accepted/Deprecated/Superseded)
+
+### The Twelve-Factor App
+
+**URL:** https://12factor.net/
+**Relevance:** Informs the Service zoom level's deployability checklist, particularly:
+- Factor III: Config (externalized configuration)
+- Factor IV: Backing services (treat as attached resources)
+- Factor VI: Processes (stateless processes)
+- Factor X: Dev/prod parity
+
+## Project History
+
+Key PRs that shaped the Architecture domain, in chronological order:
+
+| PR | What changed | Design impact |
+|----|-------------|---------------|
+| #7 | Initial Architecture review system | Established C4-inspired zoom levels, 4 subagents, prompt structure. Named "Landscape" not "Enterprise". All agents use sonnet model. |
+| #18 | Cascading maturity model added | Domain-specific maturity criteria (HYG/L1/L2/L3) in `_base.md` and `SKILL.md` |
+| #19 | Universal Hygiene gate, outcome-based levels | Removed technique names from criteria. Hygiene uses consequence-severity tests. Architecture criteria rewritten as observable outcomes. |
+| #21 | Batch orchestrator `/review-all` | Architecture runs as one of 4 parallel domains (ARC), results in `arc.md` sub-report |
+| #23 | Namespace attempt (closed, not merged) | Skill namespacing via subdirectories didn't work as expected. Led to plugin-based distribution approach (`donkey-dev/`). |
+
+## Design Decisions
+
+### Why "Landscape" not "Enterprise" (PR #7)
+
+"Enterprise" carries baggage — implies large organisations, heavy governance, ivory tower architecture. "Landscape" is neutral and descriptive — it describes the view (looking at the ecosystem) rather than the organisation type. A startup with 3 services has a landscape too.
+
+### Why all sonnet models (PR #7)
+
+Unlike SRE (where the Delivery pillar uses haiku for more binary assessments) or Security (where audit-resilience uses haiku), all 4 Architecture agents use sonnet. Architecture review at every level requires interpreting code structure against design principles — a fundamentally interpretive task. There's no "binary checklist" level in architecture.
+
+### Why outcome-based criteria (PR #19)
+
+Technique names in criteria create false negatives. "Uses DDD" excludes teams that achieve bounded contexts through other means. "Implements Clean Architecture" excludes teams that follow the dependency rule using hexagonal architecture or simply good judgement. Outcome-based criteria ("Module boundaries are explicit", "Dependencies flow inward") are technology-neutral and verifiable from code.

--- a/spec/arc/spec.md
+++ b/spec/arc/spec.md
@@ -1,0 +1,236 @@
+# Architecture Domain Specification
+
+> Canonical reference for building, improving, and maintaining the Architecture review domain within the donkey-dev Claude Code plugin.
+
+## 1. Purpose
+
+The Architecture review domain evaluates code changes through the lens of structural design. It answers one question: **"If we build this, will it age well?"**
+
+The domain produces a structured maturity assessment that tells engineering leaders:
+- What structural damage is accumulating (Hygiene failures)
+- What design foundations are missing (L1 gaps)
+- What architectural maturity looks like for this codebase (L2 criteria)
+- What excellence would require (L3 aspirations)
+
+Architecture focuses on **design-time decisions** — the choices that determine how easy the system is to understand, change, test, and extend. It complements the SRE domain (run-time behaviour), Security domain (threat exposure), and Data domain (data product quality).
+
+## 2. Audience
+
+| Who | Uses the spec for |
+|-----|-------------------|
+| **Autonomous coding agents** | Building/modifying prompt files, agent definitions, skill orchestrators |
+| **Human prompt engineers** | Reviewing agent output, calibrating severity, refining checklists |
+| **Plugin consumers** | Understanding what the Architecture review evaluates and why |
+
+## 3. Conceptual Architecture
+
+The Architecture domain is built from three interlocking layers:
+
+```
++----------------------------------------------+
+|     C4-Inspired Zoom Levels (Structure)       |   Organises WHAT to review
+|  Code . Service . System . Landscape          |   at increasing scope
++----------------------------------------------+
+|    Design Principles  <-->  Erosion Patterns  |   Analytical LENSES
+|    "What should this       "How does this     |
+|     look like?"             go wrong?"        |
++----------------------------------------------+
+|         Maturity Model (Judgement)             |   Calibrates SEVERITY
+|    Hygiene --> L1 --> L2 --> L3                |   and PRIORITY
++----------------------------------------------+
+```
+
+- **Zoom Levels** provide the structural decomposition (4 levels, 4 subagents). Each level examines the system at a different scope — from individual modules to ecosystem-wide integration.
+- **Design Principles** and **Erosion Patterns** provide the analytical duality. Principles describe what good architecture looks like; erosion patterns describe how architecture degrades. See `framework-map.md` for the complete mapping.
+- **The Maturity Model** provides the judgement framework for prioritising findings.
+
+These layers are defined in detail in the companion files:
+- `glossary.md` — canonical definitions
+- `framework-map.md` — how zoom levels, frameworks, and principles relate to each other
+- `maturity-criteria.md` — detailed criteria with "sufficient" thresholds
+- `calibration.md` — worked examples showing severity judgement
+- `anti-patterns.md` — concrete code smells per zoom level
+- `references.md` — source attribution
+
+## 4. File Layout
+
+The Architecture domain manifests as these files within the plugin:
+
+```
+donkey-dev/
+  agents/
+    arch-code.md               # Subagent: SOLID, DDD tactical, testability
+    arch-service.md            # Subagent: bounded contexts, layering, deployability
+    arch-system.md             # Subagent: stability patterns, API contracts, coupling
+    arch-landscape.md          # Subagent: integration patterns, context maps, ADRs
+  prompts/architecture/
+    _base.md                   # Shared context: zoom levels, glossary, maturity model, output format
+    code.md                    # Code zoom level checklist
+    service.md                 # Service zoom level checklist
+    system.md                  # System zoom level checklist
+    landscape.md               # Landscape zoom level checklist
+  skills/
+    review-arch/SKILL.md       # Orchestrator: scope, parallel dispatch, synthesis, output
+```
+
+### Composition rules
+
+1. **Each agent file is self-contained.** It embeds the full content of `_base.md` + its zoom-level prompt. Agents do not reference external files at runtime — all context must be inlined.
+2. **Prompts are the source of truth.** The `prompts/architecture/` directory contains the human-readable, LLM-agnostic checklists. Agent files are compiled from these.
+3. **The skill orchestrator dispatches and synthesises.** It does not contain review logic — that lives in the agents.
+
+### When modifying files
+
+| Change type | Files to update |
+|-------------|-----------------|
+| Add/change a checklist item | `prompts/architecture/<level>.md` then recompile the corresponding `agents/arch-<level>.md` |
+| Change shared context (severity, maturity, output format) | `prompts/architecture/_base.md` then recompile ALL 4 agent files |
+| Change orchestration logic | `skills/review-arch/SKILL.md` only |
+| Add a new zoom level | New prompt file, new agent file, update SKILL.md to spawn 5th agent |
+
+## 5. Design Principles
+
+These principles govern all prompt changes in the Architecture domain. They align with the cross-domain principles established in PRs #18 and #19 and must be preserved.
+
+### 5.1 Outcomes over techniques
+
+Maturity criteria describe **observable outcomes**, not named techniques, patterns, or libraries.
+
+| Bad (technique) | Good (outcome) |
+|-----------------|----------------|
+| "Uses DDD" | "Module boundaries are explicit with defined public interfaces" |
+| "Implements Clean Architecture" | "Dependencies flow inward — infrastructure depends on domain, not vice versa" |
+| "Has circuit breakers" | "External dependencies have failure isolation" |
+| "Uses ADRs" | "Design decisions are documented with rationale and trade-offs" |
+| "Follows SOLID" | "Components can be tested in isolation" |
+
+**Rationale (PR #19):** Technique names create false negatives — a team using hexagonal architecture satisfies "dependencies flow inward" but wouldn't match "implements Clean Architecture". Outcomes are technology-neutral and verifiable from code.
+
+### 5.2 Questions over imperatives
+
+Checklists use questions to prompt investigation, not imperatives to demand compliance.
+
+| Bad (imperative) | Good (question) |
+|-------------------|-----------------|
+| "Apply dependency inversion" | "Does business logic import infrastructure (database, HTTP, filesystem)?" |
+| "Document architectural decisions" | "Are significant decisions documented with rationale?" |
+| "Use bounded contexts" | "Does each service serve one cohesive domain concept?" |
+
+**Rationale:** Questions guide the reviewer to investigate the code and form a judgement. Imperatives produce binary "present/absent" assessments that miss nuance.
+
+### 5.3 Concrete anti-patterns with code examples
+
+Anti-pattern descriptions include specific code-level examples, not abstract categories.
+
+| Bad (abstract) | Good (concrete) |
+|-----------------|-----------------|
+| "Poor separation of concerns" | "Domain class imports ORM: `from sqlalchemy import Column` in `Order` entity" |
+| "High coupling" | "Module A imports Module B which imports Module A (circular dependency)" |
+| "Leaky abstraction" | "`@Entity` annotations on domain classes — persistence details in the domain layer" |
+
+### 5.4 Positive observations required
+
+Every review MUST include a "What's Good" section. Reviews that only list problems are demoralising and less actionable. Positive architectural patterns give teams confidence about what to preserve and build on.
+
+### 5.5 Hygiene gate is consequence-based
+
+The Hygiene gate uses three consequence-severity tests (Irreversible, Total, Regulated), not domain-specific checklists. This ensures consistent escalation logic across all domains.
+
+### 5.6 Severity is about structural impact
+
+| Level | Definition | Decision |
+|-------|-----------|----------|
+| **HIGH** | Fundamental design flaw — systemic risk that will compound over time | Must fix before merge |
+| **MEDIUM** | Design smell — principle violation with localised impact | May require follow-up ticket |
+| **LOW** | Style improvement — minor suggestion, no structural risk | Nice to have |
+
+Severity measures the **structural consequence** if the design ships as-is — how much harder will the system be to change, test, and operate. Not how hard the fix is.
+
+### 5.7 Zoom levels scale to project size
+
+Not every project operates at all zoom levels. The Architecture review adapts:
+- **Small project / monolith**: Code + Service always apply. System + Landscape may return "no findings" — that's correct, not a gap.
+- **Microservices**: All four levels should produce meaningful findings.
+- **Library / SDK**: Code is primary, Service may partially apply.
+
+Agents should not fabricate findings to fill a level. "No findings at this zoom level" is a valid and desirable output for projects where the level doesn't apply.
+
+### 5.8 Design-time focus
+
+Architecture reviews evaluate **design-time decisions**, not run-time behaviour. When a finding could be claimed by either Architecture or SRE, the distinction is:
+
+| Concept | Architecture asks | SRE asks |
+|---------|-------------------|----------|
+| Circuit Breaker | "Is this the right pattern?" | "Is it configured and monitored?" |
+| Coupling | "Is the dependency appropriate?" | "Does it cause cascading failure?" |
+| Error handling | "Is the error model well-designed?" | "Can operators diagnose from errors?" |
+| Deployability | "Is it independently deployable?" | "Can it be safely rolled out?" |
+
+## 6. Orchestration Process
+
+The `/review-arch` skill follows this process:
+
+### Step 1: Scope identification
+
+- File or directory argument: review that path
+- Empty or ".": review recent changes (`git diff`) or prompt for scope
+- PR number: fetch the diff
+- Determine which zoom levels are relevant to the project size
+
+### Step 2: Parallel dispatch
+
+Spawn 4 subagents simultaneously:
+
+| Agent | Model | Rationale |
+|-------|-------|-----------|
+| `arch-code` | sonnet | Nuanced judgement on SOLID compliance, DDD tactical correctness, and code quality assessment |
+| `arch-service` | sonnet | Complex analysis of bounded context alignment, layering violations, and deployability |
+| `arch-system` | sonnet | Subtle inter-service coupling analysis, stability pattern evaluation |
+| `arch-landscape` | sonnet | Complex governance analysis, context map evaluation, ADR/spec traceability |
+
+**Model selection rationale:** All four Architecture agents use sonnet because architectural review requires nuanced design judgement at every level. Unlike Security or SRE where some pillars have more binary criteria (present/absent), all architecture levels require interpreting code structure against design principles — a fundamentally interpretive task.
+
+### Step 3: Synthesis
+
+1. **Collect** findings from all 4 zoom levels
+2. **Deduplicate** — when two agents flag the same `file:line`, merge into one finding:
+   - Take the **highest severity**
+   - Take the **most restrictive maturity level** (HYG > L1 > L2 > L3)
+   - Combine recommendations from both agents
+   - Credit both zoom levels in the Zoom Level column (e.g., "Code / Service")
+3. **Aggregate maturity** — merge per-criterion assessments into one view:
+   - All criteria met = `pass`
+   - Mix of met and not met = `partial`
+   - All criteria not met = `fail`
+   - Previous level not passed = `locked`
+4. **Prioritise** — HYG findings first, then by severity (HIGH > MEDIUM > LOW)
+
+### Step 4: Output
+
+Produce the maturity assessment report per the output format defined in `_base.md`.
+
+## 7. Improvement Vectors
+
+Known gaps that future work should address, in priority order:
+
+| # | Gap | Impact | Direction |
+|---|-----|--------|-----------|
+| 1 | **No calibration examples in prompts** | Severity judgements are inconsistent across runs — the same God class might be HIGH in one review and MEDIUM in another | Add worked examples per severity per zoom level (see `calibration.md` in this spec) |
+| 2 | **Zoom level overlap on coupling** | Code-level coupling and System-level coupling are different concerns but reviewers sometimes conflate them | Clarify boundary: Code owns intra-module coupling (class-to-class), System owns inter-service coupling (service-to-service). Document in `framework-map.md` |
+| 3 | **L1 "sufficient" is undefined** | "Module boundaries are explicit with defined public interfaces" is subjective — what counts as explicit? | Define minimum thresholds (see `maturity-criteria.md`) |
+| 4 | **Landscape level over-reports on small projects** | Landscape agent sometimes flags "missing ADRs" on single-file scripts | Improve scaling guidance: agent should assess project size before reporting L2/L3 governance criteria |
+| 5 | **No technology-specific supplements** | Checklists can't recognise framework-specific patterns (e.g., Django vs Spring DI conventions) | Future: add optional supplements for Python, Java, Go, Node, .NET |
+| 6 | **DDD tactical assessment is shallow** | The code-level DDD checklist identifies Value Objects and Aggregates but doesn't evaluate their correctness deeply | Future: add concrete guidance on aggregate sizing, eventual consistency boundaries, event design |
+| 7 | **No design-decision impact analysis** | Reviews identify what's wrong but don't estimate the cost of the architectural debt | Future: add optional "change cost" qualifier (trivial / moderate / significant refactor) |
+| 8 | **No cross-review learning** | Each review is stateless | Future: use `.code-review/` history to track architectural maturity progression |
+
+## 8. Constraints
+
+Things the Architecture domain deliberately does NOT do:
+
+- **No auto-fix.** The review is read-only. Agents have Read, Grep, Glob tools only — no Bash, no Write, no Edit.
+- **No cross-domain findings.** Architecture does not flag SRE, security, or data issues. Those belong to their respective domains.
+- **No numeric scores.** Status is pass/partial/fail/locked. No percentages, no weighted scores, no "architecture health index".
+- **No prescribing specific tools.** Never recommend a specific library, framework, or vendor. Describe the outcome, let the team choose the implementation.
+- **No prescribing specific patterns by name.** Do not require "DDD" or "Clean Architecture" or "Hexagonal Architecture". Describe the structural property the code should exhibit. The team may achieve it through any approach.
+- **No fabricating findings.** If a zoom level doesn't apply to the project (e.g., Landscape for a single-service monolith), return "no findings" — do not invent concerns to fill the report.


### PR DESCRIPTION
## Summary
- Add `spec/arc/spec.md` — the canonical Architecture domain specification using C4-inspired zoom levels (Code, Service, System, Landscape), design principles vs erosion patterns analytical duality, and the maturity model
- Add 6 companion documents:
  - `glossary.md` — canonical definitions for all architecture terms, zoom levels, and design principles
  - `framework-map.md` — how zoom levels, design principles, and erosion patterns interrelate
  - `maturity-criteria.md` — detailed criteria with "sufficient" thresholds per level
  - `calibration.md` — worked examples for severity and maturity judgement
  - `anti-patterns.md` — concrete code smells organised by zoom level
  - `references.md` — source attribution for all frameworks and concepts
- Update `spec/README.md` to add the architecture spec index entry

## Test plan
- [ ] Verify spec structure: all companion files referenced in `spec.md` Section 3 exist
- [ ] Verify glossary covers all zoom levels and design principles
- [ ] Verify framework-map correctly links design principles to erosion patterns and zoom levels
- [ ] Verify maturity-criteria covers all four levels (Hygiene, L1, L2, L3) for each zoom level
- [ ] Verify file layout in Section 4 matches the planned plugin directory structure
- [ ] Verify `spec/README.md` links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)