### PR TITLE
Add Data domain specification

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -18,5 +18,4 @@ This file provides guidance on where to find standards and specifications for th
 - SRE, Site Reliability Engineering, Availability, Observability, Incident Response, CI/CD, Deployment - ./sre/spec.md
 - Security, Confidentiality, Privacy, Threat, Vulnerability, Defence, Authorisation, Authentication, Audit - ./sec/spec.md
 - Architecture, code, service, system, landscape, anti-patterns, standards, Performance, Cost, Affordability, Modular, Modularity, Composability, Composition, Scalability, Scale, Scalable, Modifiability, Modifiable, Portability, Integrability, Integration Reusability, Reuse, Testing - ./arc/spec.md
-
-
+- Data, Governance, GDPR, CCPA, PII, Query, analytics, Warehouse, Database, Schema, Table, Column, Row, Pipeline, ETL, ELT, Transform, evaluations, data contract, polyseme, published, metrics, partition, JSON, freshness - ./dat/spec.md

--- a/spec/dat/anti-patterns.md
+++ b/spec/dat/anti-patterns.md
@@ -1,0 +1,343 @@
+# Anti-Patterns Catalogue -- Data Domain
+
+> Complete catalogue of code patterns that Data reviewers should flag. Organised by pillar, with Decay Pattern / Quality Dimension classification and typical severity.
+
+## How to use this document
+
+Each anti-pattern includes:
+- **Pattern name** -- a short, memorable label
+- **What it looks like** -- concrete code description
+- **Why it's bad** -- data impact on consumers
+- **Decay Pattern / Quality Dimension** -- which failure mechanism and which missing quality property
+- **Typical severity** -- default assessment (may be higher or lower depending on context)
+
+When adding new anti-patterns to prompts, follow this structure. Use concrete descriptions, not abstract categories.
+
+---
+
+## Architecture Pillar Anti-Patterns
+
+### AP-01: Cross-domain table coupling
+
+**What it looks like:** SQL query that JOINs directly to another domain's internal tables rather than consuming from a published interface or data contract.
+
+**Why it's bad:** Any schema change in the other domain breaks this query. The coupling is invisible to the other domain -- they don't know they have a consumer. Changes cascade unpredictably.
+
+**Decay Pattern:** Schema drift
+**Quality Dimension:** Consistency (cross-domain data accessed through unstable internal interfaces)
+**Typical severity:** HIGH / L1
+
+### AP-02: Deadly diamond
+
+**What it looks like:** A DAG where the same source data reaches a target via two or more independent paths with different processing times.
+
+**Why it's bad:** The target sees data from different points in time. Fast path has today's data, slow path has yesterday's. Joins between the paths produce wrong results. Metrics may be inflated if the same records arrive via both paths.
+
+**Decay Pattern:** Silent corruption
+**Quality Dimension:** Accuracy (data from different time windows joined as if contemporaneous)
+**Typical severity:** HIGH / L1 (escalates to HYG if the target feeds financial or regulatory reporting)
+
+### AP-03: Breaking column rename
+
+**What it looks like:** `ALTER TABLE ... RENAME COLUMN` or `ALTER TABLE ... DROP COLUMN` without a multi-phase migration strategy.
+
+**Why it's bad:** All downstream consumers break immediately. If the table is widely consumed, the breakage is total. The rename cannot be undone without a backup restore.
+
+**Decay Pattern:** Schema drift
+**Quality Dimension:** Consistency (contract with consumers broken)
+**Typical severity:** HIGH / HYG (Irreversible -- data and schema permanently changed)
+
+### AP-04: Inconsistent naming conventions
+
+**What it looks like:** Mixed casing styles in the same table or across related tables: `user_id`, `firstName`, `LAST_NAME`, `EmailAddress`.
+
+**Why it's bad:** Consumers cannot predict column names. Copy-paste queries fail on case-sensitive platforms. New team members waste time figuring out the naming pattern.
+
+**Decay Pattern:** Schema drift (slow, insidious)
+**Quality Dimension:** Consistency
+**Typical severity:** MEDIUM / L1
+
+### AP-05: Missing global identifier for polyseme
+
+**What it looks like:** A table that references a cross-domain concept (customer, product, order) using only a local ID with no global identifier.
+
+**Why it's bad:** Cross-domain joins are impossible or require a fragile mapping table. If the local ID scheme changes, all cross-domain references break.
+
+**Decay Pattern:** Schema drift
+**Quality Dimension:** Consistency (no interoperability mechanism)
+**Typical severity:** MEDIUM / L1
+
+### AP-06: Schema inappropriate for use case
+
+**What it looks like:** A highly normalised (3NF) schema used for analytical queries, or a denormalised star schema used for transactional updates.
+
+**Why it's bad:** Wrong schema design creates permanent performance problems. 3NF for analytics means expensive multi-table joins on every query. Star schema for OLTP means update anomalies and denormalisation drift.
+
+**Decay Pattern:** Silent corruption (for star schema OLTP -- update anomalies)
+**Quality Dimension:** Validity (data model doesn't match access pattern)
+**Typical severity:** MEDIUM / L1
+
+### AP-07: No data contract for published interface
+
+**What it looks like:** A table consumed by multiple teams or systems with no documentation of schema stability, quality expectations, or change management process.
+
+**Why it's bad:** Consumers have no way to know what's stable, what might change, or what quality to expect. The producer has no way to know who their consumers are. Breaking changes are discovered by breakage.
+
+**Decay Pattern:** Schema drift + Ownership erosion
+**Quality Dimension:** Consistency + Completeness
+**Typical severity:** MEDIUM / L2
+
+---
+
+## Engineering Pillar Anti-Patterns
+
+### EP-01: Fan-out join without aggregation guard
+
+**What it looks like:** `SUM(orders.amount)` after joining orders to line_items, inflating the sum by the number of line items per order.
+
+**Why it's bad:** Metrics are systematically wrong. The query runs without error and produces plausible-looking numbers. The inflation may not be obvious unless someone manually reconciles.
+
+**Decay Pattern:** Silent corruption
+**Quality Dimension:** Accuracy (aggregation logic is wrong)
+**Typical severity:** HIGH / L1 (escalates to HYG if the metric feeds financial reporting)
+
+### EP-02: Silent type coercion
+
+**What it looks like:** `pd.to_numeric(df['amount'], errors='coerce')` -- invalid values silently converted to NaN with no logging.
+
+**Why it's bad:** Invalid data is destroyed without a trace. Downstream aggregations are understated. Nobody knows records were lost.
+
+**Decay Pattern:** Silent corruption
+**Quality Dimension:** Accuracy (invalid data silently removed)
+**Typical severity:** HIGH / HYG (Irreversible -- original values are lost and aggregates are wrong)
+
+### EP-03: Non-deterministic transformation
+
+**What it looks like:** `datetime.now()`, `random.random()`, or `uuid4()` used in business logic (not just metadata timestamps).
+
+**Why it's bad:** Re-running the pipeline produces different results. Idempotency is broken. Debugging is impossible because you can't reproduce the original output.
+
+**Decay Pattern:** Silent corruption (on re-runs)
+**Quality Dimension:** Uniqueness (different outputs per run)
+**Typical severity:** MEDIUM / L1
+
+### EP-04: NULL handling in JOIN conditions
+
+**What it looks like:** `WHERE region = @region` where `@region` can be NULL, silently matching zero rows because `NULL = NULL` is false in SQL.
+
+**Why it's bad:** The query silently returns an empty result set or a subset of expected data. The error is invisible -- no exception, no warning.
+
+**Decay Pattern:** Silent corruption
+**Quality Dimension:** Completeness (records silently excluded)
+**Typical severity:** HIGH / L1
+
+### EP-05: Full table scan when partition available
+
+**What it looks like:** `SELECT * FROM events WHERE event_date = '2024-01-15'` without including the partition column in the predicate.
+
+**Why it's bad:** Scans the entire table instead of a single partition. Cost scales with table size, not query selectivity. In a shared warehouse, this can consume compute budget that affects other users.
+
+**Decay Pattern:** (Performance, not a decay pattern)
+**Quality Dimension:** (Cost/performance concern)
+**Typical severity:** MEDIUM / L1 (escalates to HYG if it exhausts shared compute -- Total)
+
+### EP-06: Implicit type coercion in predicates
+
+**What it looks like:** `WHERE user_id = '123'` when `user_id` is an INTEGER column.
+
+**Why it's bad:** The database must coerce the string to an integer for every row, preventing index use. Some databases may produce unexpected results if the coercion is ambiguous.
+
+**Decay Pattern:** (Performance concern)
+**Quality Dimension:** Validity (type mismatch)
+**Typical severity:** LOW / L1
+
+### EP-07: No error handling for external enrichment
+
+**What it looks like:** `result = requests.get(api_url).json()` -- no try/except, no timeout, no retry, no fallback.
+
+**Why it's bad:** API failure crashes the entire pipeline. No partial result handling. Error message is a Python traceback with no business context.
+
+**Decay Pattern:** Silent corruption (if partial results are written before the crash)
+**Quality Dimension:** Validity (no input validation on external data)
+**Typical severity:** MEDIUM / L1
+
+### EP-08: Missing idempotency on writes
+
+**What it looks like:** Bare `INSERT INTO` without any deduplication mechanism (no MERGE, no DELETE-INSERT, no ON CONFLICT).
+
+**Why it's bad:** Pipeline re-run after failure creates duplicates. Duplicate records inflate counts, sums, and other aggregates.
+
+**Decay Pattern:** Silent corruption
+**Quality Dimension:** Uniqueness (duplicates on re-run)
+**Typical severity:** HIGH / L1
+
+### EP-09: Cartesian join (missing join condition)
+
+**What it looks like:** `FROM table_a, table_b` or `CROSS JOIN` without an intentional business reason.
+
+**Why it's bad:** Produces rows = table_a rows x table_b rows. For tables with millions of rows, this can exhaust memory, compute, and storage. The result is meaningless.
+
+**Decay Pattern:** Silent corruption (meaningless output that may pass row count checks)
+**Quality Dimension:** Accuracy
+**Typical severity:** HIGH / L1 (escalates to HYG if it exhausts shared resources -- Total)
+
+---
+
+## Quality Pillar Anti-Patterns
+
+### QP-01: No freshness tracking
+
+**What it looks like:** A table with no `loaded_at` timestamp, no watermark column, and no way to tell when the data was last updated.
+
+**Why it's bad:** Consumers cannot tell if data is current or stale. If the pipeline fails silently, yesterday's data is served as today's. No monitoring can be built because there's nothing to measure.
+
+**Decay Pattern:** Freshness degradation
+**Quality Dimension:** Timeliness (currency is unmeasurable)
+**Typical severity:** MEDIUM / L2
+
+### QP-02: No uniqueness constraint on business key
+
+**What it looks like:** Business key (order_number, customer_id + date) without a UNIQUE constraint, relying on the surrogate key (auto-increment id) for uniqueness.
+
+**Why it's bad:** Duplicate business records accumulate silently. Aggregations are inflated. The duplicates may not be discovered until a downstream report is questioned.
+
+**Decay Pattern:** Silent corruption
+**Quality Dimension:** Uniqueness
+**Typical severity:** HIGH / L1
+
+### QP-03: Undocumented magic numbers
+
+**What it looks like:** `df[df['status'].isin([1, 3, 7])]` -- filtering by numeric codes with no documentation of what the codes mean.
+
+**Why it's bad:** New team members can't maintain the code. If the source system adds a new status code, this filter silently excludes it. The business logic is locked in the author's head.
+
+**Decay Pattern:** Ownership erosion
+**Quality Dimension:** Completeness (documentation missing)
+**Typical severity:** MEDIUM / L1
+
+### QP-04: No volume monitoring
+
+**What it looks like:** A pipeline that loads data with no check on whether the load delivered a reasonable number of rows.
+
+**Why it's bad:** An empty load (0 rows) or a tiny load (source system down, only partial data) is accepted without question. Consumers see a gap in data but no alert fires.
+
+**Decay Pattern:** Freshness degradation (missing data appears as staleness)
+**Quality Dimension:** Completeness (expected records missing)
+**Typical severity:** MEDIUM / L2
+
+### QP-05: No schema change detection
+
+**What it looks like:** Pipeline ingests data from an external source with no check on whether the source schema has changed.
+
+**Why it's bad:** Source adds a column -- no impact. Source renames a column -- pipeline either crashes (best case) or silently drops the column's data (worst case). Source changes a type -- implicit coercion may produce wrong results.
+
+**Decay Pattern:** Schema drift
+**Quality Dimension:** Consistency (source and target schema can diverge undetected)
+**Typical severity:** MEDIUM / L2
+
+### QP-06: Over-engineered update frequency
+
+**What it looks like:** Real-time streaming pipeline for data that consumers only check daily.
+
+**Why it's bad:** Costs more to run. More complex to maintain. More failure modes. The extra timeliness provides no business value.
+
+**Decay Pattern:** (Not a decay pattern -- an engineering trade-off)
+**Quality Dimension:** Timeliness (over-specification, not under-specification)
+**Typical severity:** LOW / L2
+
+---
+
+## Governance Pillar Anti-Patterns
+
+### GP-01: PII in analytics without masking
+
+**What it looks like:** Raw email addresses, phone numbers, or SSNs written to analytics tables, data lakes, or exported files without hashing, tokenisation, or redaction.
+
+**Why it's bad:** Analytics layers typically have broader access controls. PII is now accessible to anyone with analytics access. Violates data minimisation and purpose limitation principles. GDPR/CCPA compliance risk.
+
+**Decay Pattern:** Compliance drift
+**Quality Dimension:** (Regulated data concern)
+**Typical severity:** HIGH / HYG (Regulated -- PII exposure)
+
+### GP-02: PII in logs
+
+**What it looks like:** PII (email, SSN, health data) interpolated into log messages, debug tables, or error output.
+
+**Why it's bad:** Logs are aggregated, retained, and often have broad access. PII cannot be selectively removed from log aggregation systems. The PII persists in log history even if the code is fixed.
+
+**Decay Pattern:** Compliance drift
+**Quality Dimension:** (Regulated data concern)
+**Typical severity:** HIGH / HYG (Regulated + Irreversible -- cannot unlog from aggregated stores)
+
+### GP-03: No retention policy
+
+**What it looks like:** Tables with no partition scheme for lifecycle management, no TTL, no scheduled purge job. Table grows forever.
+
+**Why it's bad:** Storage costs grow linearly. If the table contains PII, there's no mechanism for GDPR deletion or retention compliance. Query performance degrades as the table grows.
+
+**Decay Pattern:** Compliance drift
+**Quality Dimension:** Completeness (lifecycle metadata missing)
+**Typical severity:** MEDIUM / L2 (escalates to HYG if the table contains regulated data -- Regulated)
+
+### GP-04: No ownership metadata
+
+**What it looks like:** A table with no documented owner -- no comments, no catalog entry, no contact information.
+
+**Why it's bad:** When something goes wrong, nobody knows who to call. When the data needs updating, nobody takes responsibility. The data becomes an orphan that deteriorates over time.
+
+**Decay Pattern:** Ownership erosion
+**Quality Dimension:** Completeness (owner metadata missing)
+**Typical severity:** MEDIUM / L1
+
+### GP-05: No lineage tracking
+
+**What it looks like:** Derived tables that reference source tables with no documentation of the transformation chain. `CREATE TABLE derived AS SELECT ... FROM source` -- which source system? What upstream transformations?
+
+**Why it's bad:** Impact analysis is impossible. Root cause analysis requires code archaeology. When the source changes, nobody knows what's affected.
+
+**Decay Pattern:** Ownership erosion
+**Quality Dimension:** Accuracy (lineage correctness unverifiable)
+**Typical severity:** MEDIUM / L2
+
+### GP-06: No Right-to-be-Forgotten mechanism
+
+**What it looks like:** System processes EU citizen data but has no mechanism to identify and remove a specific user's data across all tables and downstream systems.
+
+**Why it's bad:** GDPR Article 17 requires the ability to delete personal data on request. Without a mechanism, the organisation cannot comply, risking fines of up to 4% of global revenue.
+
+**Decay Pattern:** Compliance drift
+**Quality Dimension:** (Regulated data concern)
+**Typical severity:** HIGH / HYG (Regulated -- GDPR non-compliance)
+
+### GP-07: Missing data classification
+
+**What it looks like:** A table containing sensitive data (customer records, financial transactions, health data) with no classification label indicating its sensitivity level.
+
+**Why it's bad:** Without classification, access controls can't be calibrated. Teams don't know what controls to apply. Sensitive data may be copied to less-protected environments.
+
+**Decay Pattern:** Compliance drift
+**Quality Dimension:** Completeness (classification metadata missing)
+**Typical severity:** MEDIUM / L1 (escalates to HIGH if the data is clearly PII or regulated)
+
+### GP-08: Unmasked PII in non-production environments
+
+**What it looks like:** Production data copied to development or staging environments without masking PII.
+
+**Why it's bad:** Non-production environments typically have weaker access controls. Developers and testers gain access to real customer data. Violates data minimisation principles.
+
+**Decay Pattern:** Compliance drift
+**Quality Dimension:** (Regulated data concern)
+**Typical severity:** HIGH / HYG (Regulated -- PII in uncontrolled environment)
+
+---
+
+## Adding New Anti-Patterns
+
+When adding a new anti-pattern to this catalogue or to the prompts:
+
+1. Give it a **short, memorable name** (not "Bad Practice #7")
+2. Describe **what it looks like** in code (concrete SQL/Python/config, not abstract)
+3. Explain **why it's bad** in terms of data impact on consumers
+4. Classify with **Decay Pattern** and **Quality Dimension**
+5. Assign a **typical severity** with reasoning
+6. Note **boundary conditions** that would change the severity

--- a/spec/dat/calibration.md
+++ b/spec/dat/calibration.md
@@ -1,0 +1,318 @@
+# Calibration Examples -- Data Domain
+
+> Worked examples showing how to judge severity and maturity level for real code patterns. Use these to calibrate prompt output and verify consistency across reviews.
+
+## How to use this document
+
+Each example shows:
+1. **Code pattern** -- what the reviewer sees
+2. **Assessment** -- severity, maturity level, decay pattern/quality dimension
+3. **Reasoning** -- why this severity and level, not higher or lower
+4. **Boundary note** -- what would change the assessment up or down
+
+---
+
+## Architecture Pillar
+
+### Example A1: Cross-domain table coupling (HIGH / L1)
+
+**Code pattern:**
+```sql
+SELECT o.*, c.*, p.*, i.*
+FROM sales.orders o
+JOIN customer_service.customers c ON o.customer_id = c.id
+JOIN marketing.products p ON o.product_id = p.id
+JOIN warehouse.inventory i ON p.id = i.product_id;
+```
+
+**Assessment:** HIGH | L1 | Schema drift (Consistency)
+
+**Reasoning:** This query reaches into three other domain's internal schemas. If any domain renames a column, changes a type, or restructures their tables, this query breaks. The coupling creates a maintenance burden that grows with every change in any of the four domains. This is an L1 gap (domain boundaries are not respected) and HIGH because the blast radius spans four domains.
+
+**Boundary -- would be HYG if:** The query writes results to a widely-consumed dimension table. A breakage would cascade to all downstream consumers (Total test: yes).
+
+**Boundary -- would be MEDIUM / L1 if:**
+```sql
+SELECT o.order_id, o.amount, c.customer_name
+FROM sales.orders o
+JOIN customer_service.customer_directory c ON o.customer_global_id = c.global_id;
+```
+The join uses a published interface (`customer_directory`) with a global identifier. Still cross-domain but via a contract, not internal tables. The concern shifts to whether the contract is formally defined.
+
+### Example A2: Breaking column rename (HIGH / HYG)
+
+**Code pattern:**
+```sql
+ALTER TABLE users RENAME COLUMN user_name TO username;
+```
+
+**Assessment:** HIGH | HYG | Schema drift (Irreversible test: yes)
+
+**Reasoning:** All downstream consumers that reference `user_name` break immediately. If this is a published table with multiple consumers, the breakage is instant and affects all of them simultaneously. The rename is irreversible once deployed -- consumers cannot be "un-broken" without a rollback, and any data written between deploy and rollback may reference the new name while historical queries reference the old name.
+
+**Boundary -- would be MEDIUM / L1 if:**
+```sql
+-- Phase 1: Add new column, backfill
+ALTER TABLE users ADD COLUMN username VARCHAR(255);
+UPDATE users SET username = user_name;
+-- Phase 2 (next deploy, after consumers migrate): Drop old column
+```
+Two-phase migration with a deprecation period. Consumers have time to migrate. Phase 1 is reversible.
+
+### Example A3: Deadly diamond (HIGH / L1)
+
+**Code pattern:**
+```sql
+-- Two paths to the same target:
+-- Path A: raw.orders -> enrichment.order_details -> analytics.daily_revenue (fast)
+-- Path B: raw.orders -> fraud.scored_orders -> analytics.daily_revenue (slow)
+
+INSERT INTO analytics.daily_revenue
+SELECT d.order_id, d.amount, f.fraud_score
+FROM enrichment.order_details d
+JOIN fraud.scored_orders f ON d.order_id = f.order_id
+WHERE d.order_date = CURRENT_DATE;
+```
+
+**Assessment:** HIGH | L1 | Silent corruption (Accuracy)
+
+**Reasoning:** Path A completes in minutes, Path B takes hours. The target reads today's enriched orders but yesterday's fraud scores. Revenue totals are correct but fraud flags are stale -- or if both paths produce amount data, the join may inflate totals. This is silent corruption because the query runs without error and produces a result that looks plausible but is wrong.
+
+**Boundary -- would be HYG if:** The daily_revenue table feeds a financial report or regulatory filing (Regulated test: yes, if financial reporting is involved).
+
+**Boundary -- would be MEDIUM / L2 if:** Both paths are managed by a scheduler that gates the target on completion of both upstream tasks for the same partition. The risk then shifts to whether the dependency is correctly configured.
+
+---
+
+## Engineering Pillar
+
+### Example E1: Silent type coercion (HIGH / HYG)
+
+**Code pattern:**
+```python
+df['amount'] = pd.to_numeric(df['amount'], errors='coerce')
+# Invalid values become NaN silently
+df['total'] = df.groupby('category')['amount'].transform('sum')
+```
+
+**Assessment:** HIGH | HYG | Silent corruption (Irreversible test: yes)
+
+**Reasoning:** Invalid amount values are silently converted to NaN. The subsequent `sum()` ignores NaN values, so the total is understated. This is silent -- no error, no log, no alert. The corrupted aggregates flow downstream to consumers who trust them. If those consumers make business decisions on understated totals, the damage is done before anyone detects it. Irreversible because the original invalid values are lost (coerced away) and the downstream decisions cannot be un-made.
+
+**Boundary -- would be MEDIUM / L1 if:**
+```python
+invalid_mask = pd.to_numeric(df['amount'], errors='coerce').isna() & df['amount'].notna()
+if invalid_mask.any():
+    logger.warning(f"Invalid amounts found: {invalid_mask.sum()} records",
+                   extra={"sample": df.loc[invalid_mask, 'amount'].head(5).tolist()})
+    df_rejected = df[invalid_mask]
+    # Route to dead-letter queue for investigation
+df['amount'] = pd.to_numeric(df['amount'], errors='coerce')
+```
+The coercion still happens, but invalid records are logged and preserved. The data loss is detectable and recoverable.
+
+### Example E2: Fan-out join inflating metrics (HIGH / L1)
+
+**Code pattern:**
+```sql
+SELECT
+    orders.order_id,
+    SUM(orders.amount) AS total
+FROM orders
+JOIN line_items ON orders.order_id = line_items.order_id
+GROUP BY orders.order_id;
+```
+
+**Assessment:** HIGH | L1 | Silent corruption (Accuracy)
+
+**Reasoning:** Each order has multiple line items. The join produces one row per line item, so `SUM(orders.amount)` sums the order amount once per line item, inflating the total. If an order has 3 line items, the order amount is counted 3 times. This is a common SQL error that produces results that look reasonable (the query runs, numbers come out) but are systematically wrong.
+
+**Boundary -- would be HYG if:** The inflated metric feeds a financial report or billing system (Irreversible -- invoices already sent, Regulated -- financial reporting).
+
+**Boundary -- would be MEDIUM / L1 if:** The metric is for an internal dashboard with no downstream consumers. Still wrong but impact is contained.
+
+### Example E3: Non-deterministic transformation (MEDIUM / L1)
+
+**Code pattern:**
+```python
+df['processed_at'] = datetime.now()
+df['random_sample'] = random.random()
+```
+
+**Assessment:** MEDIUM | L1 | Silent corruption (Uniqueness)
+
+**Reasoning:** `datetime.now()` produces a different value on each run, so re-runs do not produce identical output. `random.random()` is non-reproducible. This breaks idempotency -- a pipeline re-run after failure produces different results, making it impossible to verify correctness or compare outputs. MEDIUM because the data isn't necessarily wrong (timestamps may be metadata), but the pipeline is not re-runnable.
+
+**Boundary -- would be HIGH / L1 if:** `datetime.now()` is used in a business logic condition (e.g., `WHERE processed_at > cutoff`) that determines which records are included. Different runs produce different record sets.
+
+**Boundary -- would be LOW / L1 if:** `processed_at` is a metadata column only, and the pipeline uses a separate deterministic business timestamp for all logic.
+
+### Example E4: Missing error handling on external call (MEDIUM / L1)
+
+**Code pattern:**
+```python
+result = requests.get(api_url).json()
+df['enriched'] = result['data']
+```
+
+**Assessment:** MEDIUM | L1 | Silent corruption (Validity)
+
+**Reasoning:** If the API fails, returns a non-JSON response, or returns JSON without a `data` key, this crashes the pipeline with an unhandled exception. The error message will be a Python traceback with no business context. MEDIUM because the failure is at least visible (crash, not silent), but there's no handling, no retry, no dead-letter queue, and the error message doesn't help operators diagnose the issue.
+
+**Boundary -- would be HIGH / HYG if:** The API failure causes the pipeline to write a partial result (some records enriched, some not) without any indicator. Consumers get a mix of enriched and un-enriched data (Irreversible -- partial corruption).
+
+---
+
+## Quality Pillar
+
+### Example Q1: No freshness tracking (MEDIUM / L2)
+
+**Code pattern:**
+```sql
+CREATE TABLE daily_metrics (
+    metric_date DATE,
+    value DECIMAL
+);
+```
+
+**Assessment:** MEDIUM | L2 | Freshness degradation (Timeliness)
+
+**Reasoning:** There is no `loaded_at` timestamp, no `source_freshness` field, and no way to determine when this data was last updated. If the pipeline fails silently (data from yesterday is served as today's), consumers cannot tell from the data itself. This is an L2 gap because freshness monitoring requires something to measure against. MEDIUM because the data isn't wrong -- it's just impossible to verify currency.
+
+**Boundary -- would be HIGH / HYG if:** The metrics feed a real-time dashboard used for incident response. Stale data could lead to wrong operational decisions (Irreversible -- incident response actions based on stale data).
+
+**Boundary -- would be LOW / L2 if:** The table has a `loaded_at` column but no automated check compares it against an SLO. The mechanism exists but isn't monitored.
+
+### Example Q2: No uniqueness constraint on business key (HIGH / L1)
+
+**Code pattern:**
+```sql
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    order_number VARCHAR(50),
+    amount DECIMAL
+);
+```
+
+**Assessment:** HIGH | L1 | Silent corruption (Uniqueness)
+
+**Reasoning:** `order_number` is the business key but has no UNIQUE constraint. Duplicate orders will silently accumulate, inflating totals and counts. The surrogate `id` ensures row-level uniqueness but not business-level uniqueness. HIGH because duplicates in financial data produce systematically wrong aggregates.
+
+**Boundary -- would be HYG if:** The orders table feeds a billing or invoicing system. Duplicate orders mean duplicate charges (Irreversible -- money already collected, Regulated -- financial accuracy).
+
+**Boundary -- would be MEDIUM / L1 if:** The pipeline has a deduplication step downstream that handles duplicates. The constraint is still missing (defence in depth) but the practical impact is mitigated.
+
+### Example Q3: Undocumented magic numbers (MEDIUM / L1)
+
+**Code pattern:**
+```python
+df = df[df['status'].isin([1, 3, 7])]
+```
+
+**Assessment:** MEDIUM | L1 | Ownership erosion (Completeness)
+
+**Reasoning:** What do status codes 1, 3, and 7 mean? Where is this documented? If the source system adds a new status code (8), this filter silently excludes it. A new team member cannot understand or maintain this logic without asking the author. MEDIUM because the logic may be correct today, but it's unmaintainable and will silently go wrong when the source system changes.
+
+**Boundary -- would be HIGH / L1 if:** The filtered-out statuses represent active, important records. Silently excluding them causes data loss that consumers can't detect.
+
+**Boundary -- would be LOW / L1 if:**
+```python
+ACTIVE_STATUSES = [1, 3, 7]  # Active, Approved, Complete (see docs/status-codes.md)
+df = df[df['status'].isin(ACTIVE_STATUSES)]
+```
+Named constant with a documentation reference. The magic numbers are explained.
+
+---
+
+## Governance Pillar
+
+### Example G1: PII in analytics layer (HIGH / HYG)
+
+**Code pattern:**
+```python
+df_analytics = df[['user_id', 'email', 'phone', 'purchase_amount']]
+df_analytics.to_parquet('s3://analytics-bucket/user_purchases/')
+```
+
+**Assessment:** HIGH | HYG | Compliance drift (Regulated test: yes)
+
+**Reasoning:** Raw email and phone number are written to the analytics bucket without any masking, hashing, or pseudonymisation. The analytics bucket likely has broader access controls than the source system. This is a PII exposure that violates data protection principles (purpose limitation, data minimisation). Regulated: this violates GDPR/CCPA requirements for PII handling.
+
+**Boundary -- would be MEDIUM / L2 if:**
+```python
+df_analytics = df[['user_id', 'purchase_amount']]
+df_analytics['email_hash'] = df['email'].apply(lambda x: hashlib.sha256(x.encode()).hexdigest())
+df_analytics.to_parquet('s3://analytics-bucket/user_purchases/')
+```
+PII is pseudonymised (hashed). Still has governance considerations (hash is reversible with a rainbow table if not salted) but the raw PII is not exposed.
+
+### Example G2: PII in debug logging (HIGH / HYG)
+
+**Code pattern:**
+```sql
+INSERT INTO debug_log (timestamp, context)
+VALUES (NOW(), 'Processing user: email=john@example.com, ssn=123-45-6789');
+```
+
+**Assessment:** HIGH | HYG | Compliance drift (Regulated test: yes, Irreversible test: yes)
+
+**Reasoning:** PII (email, SSN) is written to a debug log table. Debug logs typically have long retention, broad access, and are often aggregated into log management systems that cannot selectively delete records. The PII cannot be "unlogged" from these aggregated stores. This triggers both the Regulated test (PII exposure) and the Irreversible test (cannot undo the logging from aggregated stores).
+
+**Boundary -- would be MEDIUM / L1 if:** The log entry contains only non-PII identifiers:
+```sql
+INSERT INTO debug_log (timestamp, context)
+VALUES (NOW(), 'Processing user: user_id=12345, request_id=abc-def');
+```
+No PII, just operational identifiers. The logging pattern is fine.
+
+### Example G3: No retention policy (MEDIUM / L2)
+
+**Code pattern:**
+```sql
+CREATE TABLE user_events (
+    event_id BIGINT,
+    user_id INT,
+    event_data JSON,
+    created_at TIMESTAMP
+);
+```
+
+**Assessment:** MEDIUM | L2 | Compliance drift (Completeness)
+
+**Reasoning:** No partition scheme for lifecycle management, no TTL, no retention policy. The table grows forever. Storage costs increase linearly. If user_events contains PII, there's no mechanism for GDPR deletion or retention compliance. MEDIUM / L2 because the data isn't wrong today, but the lack of lifecycle management will become a compliance and cost problem over time.
+
+**Boundary -- would be HIGH / HYG if:** The `event_data` JSON contains PII (health data, financial data) and the organisation is subject to GDPR/HIPAA. Unbounded retention of regulated data is a compliance violation (Regulated).
+
+**Boundary -- would be LOW / L2 if:** The table is partitioned by `created_at` and there's a scheduled job that drops old partitions. The retention mechanism exists even if it's not documented as a formal policy.
+
+### Example G4: Missing lineage (MEDIUM / L2)
+
+**Code pattern:**
+```sql
+CREATE TABLE derived_metrics AS
+SELECT customer_id, SUM(amount) AS total
+FROM source_table
+GROUP BY customer_id;
+```
+
+**Assessment:** MEDIUM | L2 | Ownership erosion (Accuracy)
+
+**Reasoning:** `source_table` is an opaque reference -- which system does it come from? What transformations were applied upstream? If `derived_metrics` produces wrong numbers, there's no way to trace back to the root cause without reading code. Impact analysis is impossible -- if `source_table` changes, nobody knows that `derived_metrics` is affected. MEDIUM / L2 because the data may be correct today, but maintainability and debuggability are compromised.
+
+**Boundary -- would be HIGH / L2 if:** The derived metrics feed external reports and the source table has multiple upstream contributors. Without lineage, a data quality issue in any upstream contributor is undiagnosable.
+
+---
+
+## Cross-pillar: How the same issue gets different assessments
+
+### Missing data contract -- assessed by different pillars
+
+A table consumed by multiple downstream teams with no formal contract:
+
+| Pillar | Decay Pattern | Emphasis |
+|--------|---------------|----------|
+| **Architecture** | Schema drift | "No versioning strategy -- a column rename will break all consumers" |
+| **Quality** | Ownership erosion | "Consumers have no documented expectations for freshness or completeness" |
+| **Governance** | Compliance drift | "No data classification on the contract -- consumers don't know if they're handling PII" |
+
+**During synthesis:** These merge into one finding if they reference the same table. The Architecture assessment sets the severity (HIGH if breaking changes are likely). The recommendation combines: "Define a data contract specifying schema stability (Architecture), quality expectations (Quality), and data classification (Governance)."

--- a/spec/dat/framework-map.md
+++ b/spec/dat/framework-map.md
@@ -1,0 +1,159 @@
+# Framework Map -- Pillars, Quality Dimensions, and Decay Patterns
+
+> How the three analytical layers in the Data domain relate to each other. Use this map when writing or reviewing prompts to ensure coverage is complete and lenses are applied correctly.
+
+## The Duality: Decay Patterns attack, Quality Dimensions defend
+
+Every Decay Pattern has one or more Quality Dimensions that mitigate it. When a reviewer identifies a decay pattern problem, they should recommend strengthening the corresponding quality dimension.
+
+| Decay Pattern | Primary Quality Dimension defence | Secondary defence | Why this pairing |
+|---------------|----------------------------------|-------------------|-----------------|
+| **Silent corruption** | **Accuracy** | Validity | Silent corruption produces wrong data that looks right; accuracy checks (reconciliation, source comparison) catch it; validity checks (constraints, ranges) prevent it at ingestion. |
+| **Schema drift** | **Consistency** | Validity | Schema drift causes consumers to misinterpret data; consistency checks (cross-system comparisons, contract enforcement) detect it; validity checks (schema enforcement) prevent it. |
+| **Ownership erosion** | **Completeness** | Accuracy | Without ownership, documentation and maintenance decay; completeness checks (metadata, field descriptions) surface the gaps; accuracy degrades as nobody validates the data against reality. |
+| **Freshness degradation** | **Timeliness** | Completeness | Stale data leads to decisions on old information; timeliness checks (freshness SLOs, processing latency) detect it; completeness checks (expected row counts) catch missing loads. |
+| **Compliance drift** | **Uniqueness** | Accuracy | Compliance drift creates uncontrolled data copies; uniqueness enforcement (primary keys, deduplication) prevents uncontrolled proliferation; accuracy (reconciliation) detects divergence between copies. |
+
+### Using the duality in reviews
+
+When writing a finding:
+1. Identify the **Decay Pattern** (how the data is going wrong)
+2. Check the **Quality Dimension defence** (what should protect against it)
+3. If the defence is missing or insufficient, that's the finding
+4. The recommendation should describe the quality dimension to strengthen, not a specific technique
+
+Example:
+- Decay Pattern: Silent corruption (fan-out join inflates metrics on line 47)
+- Quality Dimension defence needed: Accuracy (aggregation verification)
+- Finding: "1-to-many join inflates SUM(amount) -- each order counted once per line item"
+- Recommendation: "Aggregate line_items first, then join to orders. Add reconciliation check comparing source and target totals."
+
+## Pillar Focus Areas
+
+Each pillar emphasises specific Quality Dimensions and Decay Patterns. This is not exclusive -- any pillar can flag any concern -- but these are the primary focus areas that each subagent should prioritise.
+
+### Architecture pillar
+
+**Mandate:** Is the data designed right?
+
+| Decay Pattern focus | Why |
+|---------------------|-----|
+| Schema drift | Architecture owns schema design decisions. A column rename, type change, or semantic change is an architectural choice that cascades to all consumers. |
+| Silent corruption | Deadly diamonds and cross-domain coupling are architectural flaws that produce silent corruption at the structural level. |
+
+| Quality Dimension focus | Why |
+|-------------------------|-----|
+| Consistency | Schema design determines whether data is consistent across domains. Polysemes without global identifiers create systemic inconsistency. |
+| Validity | Schema constraints, type choices, and normalisation decisions determine what data can exist. |
+
+**Key review questions:**
+- Does this data model adhere to its bounded context?
+- Are shared concepts mapped using global identifiers?
+- Is the schema appropriate for the use case (OLTP vs OLAP vs streaming)?
+- Will downstream consumers break if this ships?
+
+### Engineering pillar
+
+**Mandate:** Is the data built right?
+
+| Decay Pattern focus | Why |
+|---------------------|-----|
+| Silent corruption | Engineering bugs (wrong joins, NULL handling, non-deterministic functions) produce silent corruption at the logic level. This is the most dangerous decay pattern because the pipeline "runs successfully" while producing wrong data. |
+
+| Quality Dimension focus | Why |
+|-------------------------|-----|
+| Validity | Engineering validates data at ingestion and transformation -- type checks, constraint enforcement, range validation. |
+| Uniqueness | Engineering implements idempotency (MERGE, DELETE-INSERT, UPSERT) that prevents duplicates on re-runs. |
+| Accuracy | Engineering ensures transformation logic produces correct results -- the right aggregations, correct join semantics, proper NULL handling. |
+
+**Key review questions:**
+- Is the transformation idempotent?
+- Are there tests for edge cases (NULLs, empty sets, fan-out)?
+- Can processing resume without duplicates or gaps after failure?
+- What happens when incoming data fails validation?
+
+### Quality pillar
+
+**Mandate:** Does the data meet expectations?
+
+| Decay Pattern focus | Why |
+|---------------------|-----|
+| Freshness degradation | Quality owns timeliness. If data is late, stale, or missing, consumers make decisions on outdated information. |
+| Ownership erosion | Quality owns usability. If data is undocumented, undiscoverable, or full of tribal knowledge, it fails the consumer regardless of correctness. |
+
+| Quality Dimension focus | Why |
+|-------------------------|-----|
+| Timeliness | Freshness SLOs, processing latency, appropriate update frequency. |
+| Completeness | Expected row counts, required fields not NULL, no missing loads. |
+| Accuracy | Reconciliation between source and target. Bitemporality for audit-critical data. |
+
+**Key review questions:**
+- If this data is wrong, how would we know?
+- What's the freshness SLO? Is it documented?
+- Can a new team member understand this data without asking someone?
+- What happens if source data arrives late?
+
+### Governance pillar
+
+**Mandate:** Is the data managed right?
+
+| Decay Pattern focus | Why |
+|---------------------|-----|
+| Compliance drift | Governance owns regulatory compliance. PII exposure, missing retention policies, and absent lifecycle management create legal and reputational risk. |
+| Ownership erosion | Governance owns accountability. Without clear business and technical owners, data becomes orphaned. |
+
+| Quality Dimension focus | Why |
+|-------------------------|-----|
+| Completeness | Governance verifies that required metadata is present: classification, ownership, retention policy, lineage. |
+| Accuracy | Governance verifies that lineage is correct -- data can be traced from source to destination through all transformations. |
+
+**Key review questions:**
+- What happens if a user requests their data be deleted?
+- If this data was leaked, what would be the impact?
+- Who do I contact if I have questions about this data?
+- Can we trace this data back to its original source?
+
+## Coverage Matrix
+
+This matrix shows which Decay Pattern / Quality Dimension combinations are covered by which pillar. Use it to verify that prompt changes don't create coverage gaps.
+
+| | Silent corruption | Schema drift | Ownership erosion | Freshness degradation | Compliance drift |
+|---|---|---|---|---|---|
+| **Architecture** | Primary | Primary | - | - | - |
+| **Engineering** | Primary | Secondary | - | - | - |
+| **Quality** | - | - | Primary | Primary | - |
+| **Governance** | - | - | Primary | - | Primary |
+
+| | Accuracy | Completeness | Consistency | Timeliness | Validity | Uniqueness |
+|---|---|---|---|---|---|---|
+| **Architecture** | - | - | Primary | - | Primary | - |
+| **Engineering** | Primary | - | - | - | Primary | Primary |
+| **Quality** | Primary | Primary | - | Primary | - | - |
+| **Governance** | Secondary | Primary | - | - | - | - |
+
+**Key:** Primary = core focus area for this pillar. Secondary = reviewed but not the primary lens. `-` = not a focus area (may still be flagged if found).
+
+## Inter-pillar Handoffs
+
+When a finding spans pillars, the subagent that discovers it should flag it in their own pillar's terms. The synthesis step deduplicates across pillars.
+
+Common handoff scenarios:
+
+| Scenario | Discovered by | Also relevant to |
+|----------|---------------|------------------|
+| Schema change that breaks consumers AND introduces data quality risk | Architecture | Quality (consumer impact), Engineering (migration correctness) |
+| PII in a transformation that also has correctness issues | Engineering | Governance (compliance), Quality (trust) |
+| Missing freshness SLO that also indicates unclear ownership | Quality | Governance (ownership documentation) |
+| Unbounded table growth that is both a governance gap and a quality risk | Governance | Quality (performance degradation), Engineering (query cost) |
+
+## Cross-Domain Overlaps
+
+The Data domain intentionally overlaps with other review domains. Each domain applies its own lens.
+
+| Concern | Data Review lens | Other domain lens |
+|---------|-----------------|-------------------|
+| Freshness SLOs | Quality pillar: "Is the data timely for consumers?" | SRE Availability: "Does the pipeline meet its SLO?" |
+| Query performance | Engineering pillar: "Is the query cost appropriate?" | SRE Capacity: "Will this query exhaust shared resources?" |
+| PII handling | Governance pillar: "Is PII classified and masked?" | Security Data-Protection: "Is PII encrypted and access-controlled?" |
+| Lineage | Governance pillar: "Can we trace data to its source?" | Security Audit-Resilience: "Is there an audit trail?" |
+| Schema migration | Architecture pillar: "Is this backward-compatible?" | SRE Delivery: "Can this be rolled back safely?" |

--- a/spec/dat/glossary.md
+++ b/spec/dat/glossary.md
@@ -1,0 +1,161 @@
+# Glossary -- Data Domain
+
+> Canonical definitions for all terms, frameworks, and acronyms used in the Data review domain. When writing or modifying prompts, use these definitions exactly.
+
+## Frameworks
+
+### The Four Pillars
+
+The structural framework that organises the Data review into four pillars, each with a dedicated subagent. Synthesised from DAMA DMBOK, Data Mesh, and Data Governance for Everyone.
+
+| Pillar | One-line mandate |
+|--------|-----------------|
+| **Architecture** | Is the data designed right? |
+| **Engineering** | Is the data built right? |
+| **Quality** | Does the data meet expectations? |
+| **Governance** | Is the data managed right? |
+
+### Quality Dimensions (DAMA DMBOK)
+
+Six measurable properties of trustworthy data. These are the "defensive" lens -- they describe **what makes data trustworthy**.
+
+| Dimension | Definition | Primary pillar |
+|-----------|-----------|----------------|
+| **Accuracy** | Data matches real-world truth | Quality |
+| **Completeness** | All required data is present | Quality |
+| **Consistency** | Same data across systems | Architecture |
+| **Timeliness** | Data available when needed | Quality |
+| **Validity** | Data conforms to business rules and constraints | Engineering |
+| **Uniqueness** | No unintended duplicates | Engineering |
+
+### Decay Patterns
+
+Five mechanisms by which data products degrade over time. These are the "offensive" lens -- they describe **how data goes wrong in production**.
+
+| Pattern | Definition | Recognition heuristic |
+|---------|-----------|----------------------|
+| **Silent corruption** | Data errors that propagate undetected, producing wrong results that consumers trust. | Look for: type coercion with `errors='coerce'`, fan-out joins without aggregation guards, NULL handling in JOINs that silently drops rows, missing validation on inbound data. |
+| **Schema drift** | Gradual divergence between the actual schema and what consumers expect, causing breakage or misinterpretation. | Look for: column renames without versioning, semantic changes to existing fields, naming inconsistencies, missing data contracts, no schema change detection. |
+| **Ownership erosion** | Loss of accountability over data assets, leading to orphaned datasets that nobody maintains. | Look for: no owner metadata, undocumented business rules (magic numbers), no catalog registration, no contact for questions. |
+| **Freshness degradation** | Data falling behind real-world events, causing decisions based on stale information. | Look for: no freshness SLOs, no `loaded_at` timestamps, batch processing when near-real-time is needed, no alerting on processing delays. |
+| **Compliance drift** | Governance controls weakening over time, creating regulatory exposure. | Look for: PII in logs or analytics without masking, no retention policies, tables growing forever, no Right-to-be-Forgotten mechanism, missing data classification. |
+
+### Decay Pattern -- Quality Dimension Duality
+
+Every decay pattern has corresponding quality dimensions that defend against it. When a reviewer identifies a decay pattern problem, they should recommend strengthening the corresponding quality dimensions. See `framework-map.md` for the complete mapping.
+
+## Domain Concepts
+
+| Term | Definition |
+|------|-----------|
+| **Data Product** | A self-contained, discoverable data asset with defined interfaces, quality guarantees, and ownership. The unit of data delivery in a Data Mesh architecture. |
+| **Bounded Context** | A domain boundary where a particular data model applies. Crossing boundaries requires explicit mapping through published interfaces, not direct table access. |
+| **Polyseme** | A shared concept (like 'User', 'Product', 'Order') that exists across domain boundaries and needs global identifiers for interoperability. Without global identifiers, cross-domain joins are fragile or impossible. |
+| **Data Contract** | A formal agreement between a data producer and its consumers specifying: schema (fields, types, constraints), quality expectations (freshness, completeness), and SLAs (availability, latency). |
+| **Consumer** | Any downstream system, team, or process that reads from a data product. The consumer's perspective is the primary lens for the Data review. |
+
+## Data Modelling
+
+| Term | Definition |
+|------|-----------|
+| **3NF (Third Normal Form)** | Normalised schema design for operational consistency and update anomaly prevention. Appropriate for OLTP/transactional workloads. |
+| **Star/Snowflake Schema** | Denormalised schemas with fact tables and dimensions, optimised for analytical query performance. Appropriate for OLAP/analytical workloads. |
+| **Bitemporality** | Recording both transaction time (when data was recorded in the system) and valid time (when the fact was true in reality). Essential for audit-critical data, handling late-arriving records, and supporting corrections. |
+| **Wide Table** | A denormalised, feature-rich table optimised for ML feature access patterns. Appropriate for feature stores. |
+| **Schema-on-Read** | Deferring schema enforcement to read time rather than write time. Appropriate for data lake raw layers where flexibility and late binding are prioritised. |
+
+## Processing Patterns
+
+| Term | Definition |
+|------|-----------|
+| **CDC (Change Data Capture)** | Capturing only changed records for efficient incremental processing. Avoids full table reprocessing for each pipeline run. |
+| **Deadly Diamond** | A DAG pattern where data reaches a target via multiple independent paths, causing inconsistency (timing skew between paths) or metric inflation (multiple join paths to the same dimension). Mitigated by declaring all upstream paths as dependencies and gating on completion of all paths for the same partition. |
+| **Idempotency** | Property where re-running a process with the same input produces the exact same output. Critical for data pipelines because re-runs are common (failure recovery, backfills, testing). |
+| **Watermark** | A timestamp or version marker used to track processing progress for incremental loads. Enables the pipeline to know "where it left off" after an interruption. |
+| **Fan-out** | A 1-to-many join that inflates row counts. When aggregating on the "one" side after a fan-out join, metrics are inflated. Mitigate by aggregating the "many" side first, then joining. |
+| **Dead-letter Queue** | A destination for records that fail validation or processing. Preserves failed records for inspection and reprocessing rather than silently dropping them. |
+
+## Quality and Observability
+
+| Term | Definition |
+|------|-----------|
+| **Freshness SLO** | Service Level Objective defining acceptable delay between event occurrence and data availability. Example: "Data available within 15 minutes of event" or "Daily snapshot by 6am UTC". |
+| **Event Time** | When something happened in the real world. Distinguished from processing time to detect and manage latency. |
+| **Processing Time** | When the data pipeline processed the event. The gap between event time and processing time is the processing latency. |
+| **Reconciliation** | Process of verifying data matches between source and target systems. Includes row count comparisons, sum/checksum verification, and sample record validation. |
+| **Volume Monitoring** | Tracking expected row counts per load and alerting on anomalies (0 rows, 10x expected, 0.1x expected). |
+| **Distribution Check** | Monitoring value distributions (mean/median shift, NULL percentage changes, cardinality changes) to detect data quality issues that pass row-count checks. |
+
+## Governance
+
+| Term | Definition |
+|------|-----------|
+| **Data Classification** | Categorisation of data by sensitivity: PII (Personally Identifiable Information), Confidential (business-sensitive), Internal (general business use), Public (safe to share externally). Classification determines required controls. |
+| **Crypto-shredding** | Deleting encryption keys to make encrypted data irrecoverable. Used for Right-to-be-Forgotten compliance when data is distributed across many systems and direct deletion is impractical. |
+| **RPO (Recovery Point Objective)** | Maximum acceptable data loss measured in time. "RPO of 1 hour" means the system must be recoverable to a state no more than 1 hour old. |
+| **RTO (Recovery Time Objective)** | Maximum acceptable downtime. "RTO of 4 hours" means the system must be back online within 4 hours of a failure. |
+| **Lineage** | The documented path of data from source to destination, including all transformations. Enables impact analysis ("if this source changes, what breaks?") and root cause analysis ("where did this bad data come from?"). |
+| **Purpose Limitation** | Principle that data collection and processing should be limited to a specific, valid business purpose. A GDPR requirement. |
+
+## Maturity Model
+
+### Hygiene Gate
+
+A promotion gate that overrides maturity levels. Any finding at any level is promoted to `HYG` if it passes any of these three consequence-severity tests:
+
+| Test | Question | Data examples |
+|------|----------|---------------|
+| **Irreversible** | If this goes wrong, can the damage be undone? | Pipeline silently drops records on schema mismatch (undetected data loss). Migration script with unbounded DELETE or TRUNCATE. Silent type coercion that converts invalid values to NULL without logging. |
+| **Total** | Can this take down the entire service or cascade beyond its boundary? | Unbounded query that scans the full data warehouse (resource starvation for other users). Deadly diamond that corrupts a shared dimension used by all downstream consumers. |
+| **Regulated** | Does this violate a legal or compliance obligation? | PII written to application logs or analytics without masking. Missing Right-to-be-Forgotten mechanism for GDPR-covered data. Health data stored without encryption at rest. |
+
+Any "yes" to any test = `HYG`. The Hygiene flag trumps all maturity levels.
+
+### Maturity Levels
+
+Levels are cumulative. Each requires the previous. See `maturity-criteria.md` for detailed criteria with thresholds.
+
+| Level | Name | One-line description |
+|-------|------|---------------------|
+| **L1** | Foundations | The basics are in place. The data can be understood and used. |
+| **L2** | Hardening | Production-ready practices. The data can be trusted and monitored. |
+| **L3** | Excellence | Best-in-class. The data is a model for others. |
+
+### Severity Levels
+
+| Level | Data impact | Merge decision |
+|-------|-------------|----------------|
+| **HIGH** | Data corruption, compliance violation, or consumer-breaking change | Must fix before merge |
+| **MEDIUM** | Quality degradation, performance issue, or missing documentation | May require follow-up ticket |
+| **LOW** | Style improvement or minor optimisation | Nice to have |
+
+Severity measures **data consequence**, not implementation difficulty.
+
+### Status Indicators
+
+Used in maturity assessment tables:
+
+| Indicator | Meaning |
+|-----------|---------|
+| `pass` | All criteria at this level are met |
+| `partial` | Some criteria met, some not |
+| `fail` | No criteria met, or critical criteria missing |
+| `locked` | Previous level not achieved; this level cannot be assessed |
+
+## Orchestration Terms
+
+| Term | Definition |
+|------|-----------|
+| **Pillar** | One of the 4 Data components (Architecture, Engineering, Quality, Governance). Each pillar has one subagent. |
+| **Subagent** | A specialised reviewer that analyses code against one pillar's checklist. Runs in parallel with the other 3. |
+| **Skill orchestrator** | The `/review-data` skill that dispatches subagents, collects results, deduplicates, and synthesises the final report. |
+| **Synthesis** | The process of merging 4 subagent reports into one consolidated maturity assessment. |
+| **Deduplication** | When two subagents flag the same file:line, merging into one finding with the highest severity and most restrictive maturity tag. |
+
+## Output Terms
+
+| Term | Definition |
+|------|-----------|
+| **Finding** | A single identified issue: severity, maturity level, pillar, file location, description, and recommendation. |
+| **Maturity assessment** | Per-criterion evaluation (met/not met/partially met) for each maturity level. |
+| **Immediate action** | The single most important thing to fix. Hygiene failure if any exist, otherwise the top finding from the next achievable level. |

--- a/spec/dat/maturity-criteria.md
+++ b/spec/dat/maturity-criteria.md
@@ -1,0 +1,317 @@
+# Maturity Criteria -- Data Domain
+
+> Detailed criteria for each maturity level with defined "sufficient" thresholds. Use this when assessing criteria as Met / Not met / Partially met.
+
+## Hygiene Gate
+
+The Hygiene gate is not a maturity level -- it is a promotion gate. Any finding at any level that passes any of the three tests is promoted to `HYG`.
+
+### Test 1: Irreversible
+
+**Question:** If this goes wrong, can the damage be undone?
+
+**Threshold:** If a failure would produce damage that requires more than a re-run or rollback to fix -- e.g., silently corrupted data that has already been consumed by downstream systems, deleted records with no backup, PII leaked to an uncontrolled output -- this is irreversible.
+
+**Data examples that trigger this test:**
+- Pipeline silently drops records on schema mismatch with no error or dead-letter queue -- consumers believe the data is complete, but records are missing
+- `pd.to_numeric(df['amount'], errors='coerce')` -- invalid values silently become NaN, aggregate metrics are wrong, and nobody knows
+- Migration script with unbounded `DELETE` or `TRUNCATE` without a backup step
+- Fan-out join that inflates a financial metric -- business decisions made on inflated numbers before anyone notices
+- Background job that purges records before confirming downstream receipt
+
+**Data examples that do NOT trigger this test:**
+- Missing schema documentation (bad practice but reversible -- documentation can be added)
+- Inefficient query (costs money but doesn't corrupt data)
+- Naming convention violation (style issue, no data impact)
+
+### Test 2: Total
+
+**Question:** Can this take down the entire service or cascade beyond its boundary?
+
+**Threshold:** If a failure can exhaust shared resources (warehouse compute, storage, network) to the point where other workloads are affected, or if the failure propagates corruption to other data products beyond the producer's boundary, this is total.
+
+**Data examples that trigger this test:**
+- Unbounded `SELECT *` in a shared data warehouse that consumes all available compute slots, blocking other teams' queries
+- Deadly diamond that corrupts a shared dimension table used by all downstream analytics
+- Schema change on a high-fan-out table (many consumers) without versioning -- all consumers break simultaneously
+- Pipeline with no circuit breaker that retries a failing source indefinitely, consuming rate limit budget for all users
+
+**Data examples that do NOT trigger this test:**
+- A single pipeline fails and produces no output (localised failure, consumers see stale data but not corrupt data)
+- A query is slow but doesn't block other users (performance issue, not total failure)
+
+### Test 3: Regulated
+
+**Question:** Does this violate a legal or compliance obligation?
+
+**Threshold:** If the code would cause a breach of data protection law (GDPR, CCPA, HIPAA), financial regulation, or other legal obligations, this is regulated.
+
+**Data examples that trigger this test:**
+- PII (emails, phone numbers, SSN, health data) written to application logs without masking
+- Raw PII exported to an analytics layer without pseudonymisation or access controls
+- No mechanism for Right-to-be-Forgotten (GDPR Article 17) when processing EU citizen data
+- Health data stored without encryption at rest (HIPAA violation)
+- Financial data used for purposes beyond the original consent (purpose limitation violation)
+
+**Data examples that do NOT trigger this test:**
+- Internal aggregate metrics without PII (no personal data involved)
+- Missing data classification labels on non-sensitive data (good practice but not a legal violation)
+- Ownership metadata missing (governance gap, not a compliance violation unless regulated data is involved)
+
+---
+
+## Level 1 -- Foundations
+
+**Overall intent:** The basics are in place. The data can be understood, used, and maintained. A new team member can work with this data without relying on tribal knowledge.
+
+### Criterion 1.1: Schemas are documented with field-level descriptions
+
+**Definition:** Every table, view, or data model has documentation that describes what it contains, and fields have individual descriptions explaining their business meaning.
+
+**Met (sufficient):**
+- Table/model has a description (purpose, source, grain)
+- Fields have descriptions that explain business meaning, not just technical type
+- Descriptions use terminology that a consumer (not just the producer) can understand
+- At minimum: all fields in published/external-facing tables are described
+
+**Partially met:**
+- Table has a description but fields don't, or only some fields are described
+- Descriptions exist but are auto-generated placeholders ("column_1 description")
+- Descriptions exist but use producer-internal jargon that consumers can't understand
+
+**Not met:**
+- No descriptions on tables or fields
+- Descriptions exist only in external documentation that is not co-located with the schema
+- Schema is completely undocumented -- understanding requires reading pipeline code
+
+### Criterion 1.2: Each data asset has a defined owner
+
+**Definition:** Every table, pipeline, or data product has a clearly identified owner -- both a business owner (accountable for data value and rules) and a technical owner (accountable for quality and operations).
+
+**Met (sufficient):**
+- Owner is declared in metadata, schema comments, catalog, or configuration
+- Both business and technical ownership are identifiable (may be the same team for small orgs)
+- Owner information is findable without asking someone (discoverable from the data asset itself)
+
+**Partially met:**
+- Technical owner identifiable (from git blame, pipeline config) but no business owner
+- Owner documented in an external system (wiki, spreadsheet) but not in the data asset's metadata
+- Some assets have owners, others don't
+
+**Not met:**
+- No owner information anywhere
+- Ownership can only be determined by asking around ("Who owns this table?")
+
+### Criterion 1.3: Input data is validated
+
+**Definition:** Data entering the pipeline is checked for type correctness, constraint adherence, and referential integrity before it is processed and served to consumers.
+
+**Met (sufficient):**
+- Input data types are enforced (not silently coerced)
+- Required fields are checked for NULL
+- Primary key uniqueness is enforced
+- At minimum: validation exists on the first ingestion boundary (where external data enters the system)
+- Validation failures are visible (logged, alerted, or routed to a dead-letter queue) -- not silently dropped
+
+**Partially met:**
+- Some validation exists but doesn't cover all fields or all ingestion points
+- Validation exists but failures are silently swallowed (logged at DEBUG with no alerting)
+- Type checking exists but referential integrity is not validated
+
+**Not met:**
+- No validation on inbound data
+- Validation exists but silently coerces invalid data (e.g., `errors='coerce'`) with no logging
+- Schema mismatches cause silent record drops
+
+### Criterion 1.4: Processing is idempotent
+
+**Definition:** Re-running a pipeline with the same input produces the exact same output. No duplicates, no missing records, no side effects from multiple executions.
+
+**Met (sufficient):**
+- Write strategy is inherently idempotent: MERGE/UPSERT, DELETE-INSERT by partition, or INSERT with conflict resolution
+- Non-deterministic functions (`NOW()`, `RANDOM()`, `UUID()`) are either avoided or seeded/pinned
+- Processing does not depend on execution order when parallelised
+- Re-running after a failure does not produce duplicates
+
+**Partially met:**
+- Write strategy is mostly idempotent but some paths use bare INSERT (append-only without deduplication)
+- Non-deterministic functions are used but the impact is limited (e.g., `loaded_at` timestamp differs but data is otherwise identical)
+- Idempotency works for normal runs but edge cases (partial failure mid-write) can produce duplicates
+
+**Not met:**
+- Bare INSERT with no deduplication -- re-runs always produce duplicates
+- Pipeline depends on `NOW()` for business logic (different result on each run)
+- No mechanism to handle partial failure (interrupted write leaves partial data)
+
+---
+
+## Level 2 -- Hardening
+
+**Overall intent:** Production-ready practices. The data can be trusted and monitored. Teams can set and track quality targets. Consumers have confidence in the data.
+
+**Prerequisite:** All L1 criteria must be met.
+
+### Criterion 2.1: Freshness expectations are defined and monitored
+
+**Definition:** There are explicit expectations for when data should be available, and the system can detect when those expectations are not met.
+
+**Met (sufficient):**
+- Freshness SLO is defined (documented or in configuration) -- e.g., "available within 15 minutes of event", "daily snapshot by 6am UTC"
+- Processing latency (gap between event time and data availability) is measurable from the data itself (`loaded_at` timestamps, watermarks)
+- There is a mechanism to detect when freshness degrades (alert, monitoring check, or automated test)
+
+**Partially met:**
+- Freshness expectation exists informally ("we expect it by morning") but is not documented or measured
+- `loaded_at` timestamps exist but no automated check compares them against a target
+- Monitoring exists but the SLO threshold is not defined (alert fires on "no data" but not on "late data")
+
+**Not met:**
+- No freshness expectation defined
+- No way to tell when data was last updated (no `loaded_at`, no watermark, no processing timestamp)
+- Consumers discover staleness by noticing wrong results, not from monitoring
+
+### Criterion 2.2: Contracts exist between producers and consumers
+
+**Definition:** Published data products have a formal or semi-formal agreement about what the consumer can expect: schema stability, quality guarantees, and change management process.
+
+**Met (sufficient):**
+- Schema is versioned or has a stability guarantee (consumers know which fields are stable)
+- Breaking changes have a defined process: notification, deprecation period, migration support
+- Quality expectations are documented: what validation is applied, what completeness guarantees exist
+- At minimum: a YAML/JSON contract file, schema documentation with stability labels, or explicit API versioning
+
+**Partially met:**
+- Schema is documented but there's no process for managing breaking changes
+- Contract exists but only covers schema, not quality or freshness expectations
+- Breaking changes are communicated ad hoc (Slack message) rather than through a defined process
+
+**Not met:**
+- No contract -- consumers discover changes by breakage
+- Breaking changes deployed without notification
+- No distinction between internal (can change anytime) and published (stable) interfaces
+
+### Criterion 2.3: Data can be traced from source to destination
+
+**Definition:** For any data product, the lineage is clear: where did the data come from, what transformations were applied, and where does it go?
+
+**Met (sufficient):**
+- Source systems are identified for each data product
+- Transformations are documented or self-documenting (declarative pipeline definitions, SQL with clear source references)
+- Impact analysis is possible: "if source X changes, what downstream products are affected?"
+- Lineage is captured automatically (from pipeline metadata, DAG definitions) or maintained alongside the code
+
+**Partially met:**
+- Source is known but intermediate transformations are opaque (complex SQL without documentation)
+- Lineage exists for some pipelines but not all
+- Lineage is documented but not maintained (outdated)
+
+**Not met:**
+- No lineage information -- "where does this data come from?" requires code archaeology
+- Derived tables reference source names that don't map to any known system
+- Transformations are undocumented and pipeline logic is opaque
+
+### Criterion 2.4: Quality is monitored with automated checks
+
+**Definition:** Data quality is verified through automated checks that run as part of the pipeline, not just during development.
+
+**Met (sufficient):**
+- Automated checks exist for at minimum: row count expectations, NULL rates on required fields, uniqueness on primary keys
+- Checks run in production (part of the pipeline or a scheduled validation job)
+- Check failures are visible (alerts, pipeline failure, dashboard)
+- Checks cover both structural quality (schema conformance) and content quality (value ranges, distributions)
+
+**Partially met:**
+- Some automated checks exist but coverage is spotty (only row counts, no content checks)
+- Checks exist in development/CI but not in production
+- Checks run but failures are only logged (no alerting, no pipeline halt)
+
+**Not met:**
+- No automated data quality checks
+- Quality issues discovered by consumers ("these numbers look wrong")
+- Checks exist only as manual spot-checks
+
+### Criterion 2.5: Source and target are reconciled
+
+**Definition:** There is a verification mechanism that compares source data with the target to confirm that the pipeline hasn't introduced errors, lost records, or created duplicates.
+
+**Met (sufficient):**
+- At least one reconciliation mechanism exists: row count comparison, sum verification, or checksum matching
+- Reconciliation runs automatically (part of the pipeline or scheduled)
+- Discrepancies trigger a visible signal (alert, log, or pipeline failure)
+
+**Partially met:**
+- Reconciliation exists but is manual (someone runs a query periodically)
+- Row count check exists but no content-level verification (could have right count but wrong data)
+- Reconciliation runs but discrepancies are only logged (no alert)
+
+**Not met:**
+- No reconciliation between source and target
+- The pipeline is assumed correct if it doesn't error
+- Discrepancies are discovered by consumers
+
+---
+
+## Level 3 -- Excellence
+
+**Overall intent:** Best-in-class. The data products are a model for others. Data management is a first-class engineering discipline.
+
+**Prerequisite:** All L2 criteria must be met.
+
+### Criterion 3.1: Temporal changes are tracked for audit-critical data
+
+**Definition:** For data where historical accuracy matters (financial, regulatory, compliance), the system tracks both when data changed in reality and when it was recorded.
+
+**Met (sufficient):**
+- Bitemporality is implemented for audit-critical tables: transaction time (system recorded) and valid time (reality)
+- Late-arriving data and corrections are handled without overwriting history
+- Point-in-time queries are possible ("what did we know about this customer as of last Tuesday?")
+
+**Partially met:**
+- Transaction time is tracked (audit log of changes) but valid time is not
+- History is preserved but point-in-time queries are not straightforward (requires complex joins)
+- Bitemporality is implemented for some audit-critical tables but not all
+
+**Not met:**
+- No temporal tracking -- current state only (UPDATE in place)
+- Changes overwrite previous values with no history
+- Late-arriving data causes retroactive changes to historical reports
+
+### Criterion 3.2: Data assets are discoverable without tribal knowledge
+
+**Definition:** A person or system can find, understand, and evaluate a data product without asking the producer directly.
+
+**Met (sufficient):**
+- Data products are registered in a catalog or discovery mechanism
+- Each product has: description, owner, freshness information, quality indicators, sample data or preview
+- Search and filtering works (by domain, by tag, by owner)
+- Documentation is sufficient for self-service consumption
+
+**Partially met:**
+- Catalog exists but is incomplete (not all products registered)
+- Products are listed but metadata is sparse (name only, no description or quality info)
+- Discovery requires knowledge of the catalog's existence (not linked from the data itself)
+
+**Not met:**
+- No catalog or discovery mechanism
+- Finding data requires asking someone or browsing file systems
+- Data products are only known through word of mouth
+
+### Criterion 3.3: Reconciliation runs automatically with alerting on divergence
+
+**Definition:** Source-to-target reconciliation is fully automated and produces alerts when discrepancies exceed thresholds.
+
+**Met (sufficient):**
+- Reconciliation runs automatically as part of the pipeline or on a schedule
+- Thresholds are defined for acceptable divergence (not just zero-tolerance)
+- Alerts fire when thresholds are exceeded
+- Alert includes context: which records diverge, by how much, since when
+
+**Partially met:**
+- Reconciliation is automated but alerting is not configured
+- Alerting exists but thresholds are too sensitive (alert fatigue) or too loose (real issues missed)
+- Automated for some pipelines but not all critical ones
+
+**Not met:**
+- Reconciliation is manual
+- No divergence detection
+- Discrepancies discovered by consumers or during audits

--- a/spec/dat/references.md
+++ b/spec/dat/references.md
@@ -1,0 +1,161 @@
+# References -- Data Domain
+
+> Source attribution for all frameworks, concepts, and terminology used in the Data review domain. Cite these when asked about the origin of a concept. Update this file when new sources are introduced.
+
+## Framework Origins
+
+### The Four Pillars (Architecture, Engineering, Quality, Governance)
+
+**Origin:** Original to this project, synthesised from multiple sources.
+**Status:** The structural backbone of the Data review domain. Organises the review into 4 pillars, each with a dedicated subagent.
+**Design rationale:** The pillars map naturally to the concerns of different stakeholders: architects care about design, engineers care about code quality, consumers care about quality, and compliance teams care about governance.
+**Derivation:**
+- Architecture pillar draws from DAMA DMBOK (Data Modeling & Design) and Data Mesh (domain ownership, interoperability)
+- Engineering pillar draws from general software engineering practice (testing, idempotency, performance)
+- Quality pillar draws from DAMA DMBOK (Data Quality Management) and Data Mesh (data product quality guarantees)
+- Governance pillar draws from DAMA DMBOK (Data Governance, Data Security) and Data Governance for Everyone
+
+### Quality Dimensions (Accuracy, Completeness, Consistency, Timeliness, Validity, Uniqueness)
+
+**Origin:** DAMA DMBOK -- Data Management Body of Knowledge.
+**Status:** Used as the "defensive" analytical lens -- describes what makes data trustworthy.
+**How it's used:** Each quality dimension maps to specific checklist items across pillars. Findings recommend strengthening specific quality dimensions. See `framework-map.md` for dimension-to-pillar mapping.
+
+### Decay Patterns (Silent corruption, Schema drift, Ownership erosion, Freshness degradation, Compliance drift)
+
+**Origin:** Original to this project, derived from observed failure modes in data systems.
+**Status:** Used as the "offensive" analytical lens -- describes how data products degrade over time.
+**How it's used:** Paired with Quality Dimensions to form the duality (attack/defence). Findings are classified by decay pattern. See `framework-map.md` for the complete mapping.
+**Design rationale (why these five):**
+- **Silent corruption** -- the most dangerous data failure because it's invisible. Drawn from industry experience with fan-out joins, type coercion, and NULL handling.
+- **Schema drift** -- the most common data breakage. Drawn from Data Mesh's emphasis on data contracts and interface stability.
+- **Ownership erosion** -- the root cause of most governance failures. Drawn from Data Governance for Everyone's emphasis on practical accountability.
+- **Freshness degradation** -- the most impactful quality failure for decision-making. Drawn from Data Mesh's data product quality guarantees.
+- **Compliance drift** -- the highest-risk failure for organisations. Drawn from GDPR/CCPA requirements and DAMA DMBOK governance principles.
+
+### Maturity Model (Hygiene, L1, L2, L3)
+
+**Origin:** Original to this project.
+**Design history:**
+- PR #13/Issue #13: Initial maturity scoring concept -- hygiene factors vs aspirational targets
+- PR #14/Issue #14: Separated hygiene factors from aspirational targets
+- PR #18: Added domain-specific maturity criteria to all 4 review domains including Data
+- PR #19: Rewrote as universal Hygiene gate (Irreversible/Total/Regulated) with outcome-based levels. Removed technique names from criteria.
+
+**Key design decision (PR #19):** The Hygiene gate uses consequence-severity tests, not domain-specific checklists. This ensures the same escalation logic across Architecture, SRE, Security, and Data domains.
+
+## Books and Publications
+
+### DAMA-DMBOK: Data Management Body of Knowledge (2nd Edition)
+
+**Authors:** DAMA International
+**Published:** 2017, Technics Publications
+**ISBN:** 978-1634622349
+**Relevance:** The foundational reference for data management practice. Defines the quality dimensions, governance principles, and data management knowledge areas that underpin the Data review domain.
+**Specific areas referenced:**
+- Chapter 3: Data Governance -- Roles, policies, accountability structures
+- Chapter 5: Data Modeling and Design -- Schema design patterns, normalisation, dimensional modeling
+- Chapter 6: Data Storage and Operations -- Lifecycle management, retention, archiving
+- Chapter 8: Data Integration and Interoperability -- ETL, CDC, data contracts
+- Chapter 13: Data Quality Management -- Quality dimensions, measurement, monitoring
+
+### Data Mesh: Delivering Data-Driven Value at Scale
+
+**Author:** Zhamak Dehghani
+**Published:** 2022, O'Reilly Media
+**ISBN:** 978-1492092391
+**Relevance:** Defines the data-as-product paradigm that shapes the Data review's consumer-first perspective. Introduces data product properties, domain ownership, and self-serve data infrastructure.
+**Specific concepts referenced:**
+- Data as a product (Chapter 5) -- discoverable, addressable, trustworthy, self-describing, interoperable, secure
+- Domain ownership (Chapter 4) -- bounded contexts for data, polysemes, global identifiers
+- Computational governance (Chapter 9) -- automated policy enforcement, standards
+- Data contracts (Chapter 7) -- producer-consumer agreements, schema stability
+
+### Data Governance: The Definitive Guide
+
+**Author:** Evren Eryurek, Uri Gilad, Valliappa Lakshmanan, Anita Kibunguchy-Grant, Jessi Ashdown
+**Published:** 2021, O'Reilly Media
+**ISBN:** 978-1492063490
+**Relevance:** Practical governance guidance that complements DAMA DMBOK's theoretical framework. Informs the Governance pillar's approach to classification, PII handling, and lifecycle management.
+
+### Fundamentals of Data Engineering
+
+**Authors:** Joe Reis, Matt Housley
+**Published:** 2022, O'Reilly Media
+**ISBN:** 978-1098108304
+**Relevance:** Practical engineering patterns for data pipelines. Informs the Engineering pillar's checklists on idempotency, CDC, orchestration, and error handling.
+**Specific topics referenced:**
+- Chapter 5: Data Generation in Source Systems -- CDC patterns, event-driven architectures
+- Chapter 8: Batch Ingestion Considerations -- Idempotency, incremental processing, watermarks
+- Chapter 9: Serving Data -- Materialised views, data products, access patterns
+
+### Designing Data-Intensive Applications
+
+**Author:** Martin Kleppmann
+**Published:** 2017, O'Reilly Media
+**ISBN:** 978-1449373320
+**Relevance:** Deep technical reference for data system design patterns. Informs understanding of exactly-once semantics, idempotency, event sourcing, and consistency guarantees.
+**Specific chapters referenced:**
+- Chapter 7: Transactions -- Exactly-once semantics, idempotency
+- Chapter 11: Stream Processing -- Watermarks, event time vs processing time, late data handling
+- Chapter 12: The Future of Data Systems -- Data integration patterns
+
+### The Data Warehouse Toolkit (3rd Edition)
+
+**Author:** Ralph Kimball, Margy Ross
+**Published:** 2013, Wiley
+**ISBN:** 978-1118530801
+**Relevance:** Definitive reference for dimensional modelling. Informs the Architecture pillar's schema design guidance for star/snowflake schemas, fact tables, dimensions, and slowly changing dimensions.
+
+## Standards and Industry References
+
+### GDPR (General Data Protection Regulation)
+
+**URL:** https://gdpr-info.eu/
+**Relevance:** The primary regulatory framework referenced in the Governance pillar. Key articles:
+- Article 5: Principles (purpose limitation, data minimisation, accuracy, storage limitation)
+- Article 17: Right to erasure (Right to be Forgotten)
+- Article 25: Data protection by design and by default
+- Article 30: Records of processing activities (lineage relevance)
+
+### CCPA (California Consumer Privacy Act)
+
+**URL:** https://oag.ca.gov/privacy/ccpa
+**Relevance:** US data privacy regulation referenced alongside GDPR. Similar requirements for data deletion, disclosure, and purpose limitation.
+
+### Great Expectations
+
+**URL:** https://greatexpectations.io/
+**Relevance:** Referenced in the Quality pillar as an example of data quality testing patterns (expectations). Used as an illustration of what automated quality checks look like, not as a required tool.
+
+### dbt (Data Build Tool)
+
+**URL:** https://www.getdbt.com/
+**Relevance:** Referenced in the Engineering pillar as an example of declarative pipeline definitions. Used as an illustration of modular, tested, documented transformations, not as a required tool.
+
+### Apache Iceberg / Delta Lake
+
+**URL:** https://iceberg.apache.org/ / https://delta.io/
+**Relevance:** Referenced in the Architecture pillar as examples of standardised table formats for interoperability. Used as illustrations, not requirements.
+
+## Project History
+
+Key PRs that shaped the Data domain, in chronological order:
+
+| PR | What changed | Design impact |
+|----|-------------|---------------|
+| #5 | Initial Data review system | Established Four Pillars architecture, 4 subagents, prompt structure. Defined "Trusted and Timely" mantra. |
+| #12 | Data domain issue | Defined acceptance criteria: 4 parallel subagents, standard severity table format, DAMA DMBOK + Data Mesh frameworks |
+| #13 | Summary reports and maturity scoring issue | Defined Data maturity criteria: HYG (no missing PII masking, no breaking schema changes), L1 (schema documented, ownership defined), L2 (freshness SLOs, data contracts), L3 (bitemporality, self-serve discovery) |
+| #18 | Cascading maturity model added | Domain-specific maturity criteria (HYG/L1/L2/L3) in `_base.md` and `SKILL.md` for Data |
+| #19 | Universal Hygiene gate, outcome-based levels | Removed technique names from criteria. Hygiene uses consequence-severity tests. Data-specific Hygiene examples added. |
+| #21 | Batch orchestrator `/review-all` | Data runs as one of 4 parallel domains, results in `dat.md` sub-report |
+
+## Attribution Notes
+
+All frameworks in the Data domain are either:
+1. **Industry-standard** (DAMA DMBOK quality dimensions, GDPR requirements) -- well-attributed
+2. **From cited publications** (Data Mesh concepts from Dehghani) -- well-attributed
+3. **Original to this project** (Four Pillars structure, Decay Patterns taxonomy) -- declared as original
+
+No attribution gaps exist for the Data domain at this time.

--- a/spec/dat/spec.md
+++ b/spec/dat/spec.md
@@ -1,0 +1,234 @@
+# Data Domain Specification
+
+> Canonical reference for building, improving, and maintaining the Data review domain within the donkey-dev Claude Code plugin.
+
+## 1. Purpose
+
+The Data review domain evaluates code changes through the lens of data product quality. It answers one question: **"If we ship this, will the data be trusted and timely?"**
+
+The domain produces a structured maturity assessment that tells engineering leaders:
+- What data integrity risks exist right now (Hygiene failures)
+- What foundational data practices are missing (L1 gaps)
+- What operational data maturity looks like for this codebase (L2 criteria)
+- What excellence would require (L3 aspirations)
+
+Data focuses on the **lifecycle of data as a product** -- from schema design through transformation, quality assurance, and governance. It complements the Architecture domain (structural design), SRE domain (run-time reliability), and Security domain (threat exposure).
+
+The guiding mantra is **Trusted and Timely**: data products must be accurate, well-governed, and available when consumers need them.
+
+## 2. Audience
+
+| Who | Uses the spec for |
+|-----|-------------------|
+| **Autonomous coding agents** | Building/modifying prompt files, agent definitions, skill orchestrators |
+| **Human prompt engineers** | Reviewing agent output, calibrating severity, refining checklists |
+| **Plugin consumers** | Understanding what the Data review evaluates and why |
+
+## 3. Conceptual Architecture
+
+The Data domain is built from three interlocking layers:
+
+```
++----------------------------------------------+
+|        Four Pillars (Structure)               |   Organises WHAT to review
+|  Architecture . Engineering .                 |
+|  Quality . Governance                         |
++----------------------------------------------+
+|  Quality Dimensions <--> Decay Patterns       |   Analytical LENSES
+|  "What makes data       "How does data        |
+|   trustworthy?"          go wrong?"           |
++----------------------------------------------+
+|         Maturity Model (Judgement)             |   Calibrates SEVERITY
+|    Hygiene --> L1 --> L2 --> L3                |   and PRIORITY
++----------------------------------------------+
+```
+
+- **The Four Pillars** provide the structural decomposition (4 pillars, 4 subagents). Each pillar examines data from a different concern -- design, code, quality, and compliance.
+- **Quality Dimensions** and **Decay Patterns** provide the analytical duality. Quality Dimensions (from DAMA DMBOK) describe the measurable properties of trustworthy data; Decay Patterns describe how data products erode over time. See `framework-map.md` for the complete mapping.
+- **The Maturity Model** provides the judgement framework for prioritising findings.
+
+These layers are defined in detail in the companion files:
+- `glossary.md` -- canonical definitions
+- `framework-map.md` -- how pillars, quality dimensions, and decay patterns relate
+- `maturity-criteria.md` -- detailed criteria with "sufficient" thresholds
+- `calibration.md` -- worked examples showing severity judgement
+- `anti-patterns.md` -- concrete code smells per pillar
+- `references.md` -- source attribution
+
+## 4. File Layout
+
+The Data domain manifests as these files within the plugin:
+
+```
+donkey-dev/
+  agents/
+    data-architecture.md     # Subagent: schema design, domain boundaries, data contracts
+    data-engineering.md      # Subagent: transformation correctness, performance, error handling
+    data-quality.md          # Subagent: freshness SLOs, validation, documentation
+    data-governance.md       # Subagent: compliance, lifecycle, ownership, lineage
+  prompts/data/
+    _base.md                 # Shared context: pillars, glossary, maturity model, output format
+    architecture.md          # Architecture pillar checklist
+    engineering.md           # Engineering pillar checklist
+    quality.md               # Quality pillar checklist
+    governance.md            # Governance pillar checklist
+  skills/
+    review-data/SKILL.md     # Orchestrator: scope, parallel dispatch, synthesis, output
+```
+
+### Composition rules
+
+1. **Each agent file is self-contained.** It embeds the full content of `_base.md` + its pillar prompt. Agents do not reference external files at runtime -- all context must be inlined.
+2. **Prompts are the source of truth.** The `prompts/data/` directory contains the human-readable, LLM-agnostic checklists. Agent files are compiled from these.
+3. **The skill orchestrator dispatches and synthesises.** It does not contain review logic -- that lives in the agents.
+
+### When modifying files
+
+| Change type | Files to update |
+|-------------|-----------------|
+| Add/change a checklist item | `prompts/data/<pillar>.md` then recompile the corresponding `agents/data-<pillar>.md` |
+| Change shared context (severity, maturity, output format) | `prompts/data/_base.md` then recompile ALL 4 agent files |
+| Change orchestration logic | `skills/review-data/SKILL.md` only |
+| Add a new pillar | New prompt file, new agent file, update SKILL.md to spawn 5th agent |
+
+## 5. Design Principles
+
+These principles govern all prompt changes in the Data domain. They align with the cross-domain principles established in PRs #18 and #19 and must be preserved.
+
+### 5.1 Outcomes over techniques
+
+Maturity criteria describe **observable outcomes**, not named techniques, patterns, or tools.
+
+| Bad (technique) | Good (outcome) |
+|-----------------|----------------|
+| "Uses dbt" | "Pipeline dependencies are declared and acyclic" |
+| "Implements Great Expectations" | "Input data is validated with automated checks" |
+| "Follows Data Mesh" | "Each data asset has a defined owner and published interface" |
+| "Uses star schema" | "Schema design is appropriate for the access pattern" |
+| "Has a data catalog" | "Data assets are discoverable without tribal knowledge" |
+
+**Rationale (PR #19):** Technique names create false negatives -- a team using SQLMesh satisfies "pipeline dependencies are declared" but wouldn't match "uses dbt". Outcomes are technology-neutral and verifiable from code.
+
+### 5.2 Questions over imperatives
+
+Checklists use questions to prompt investigation, not imperatives to demand compliance.
+
+| Bad (imperative) | Good (question) |
+|-------------------|-----------------|
+| "Document all schemas" | "Can a new team member understand this data without asking someone?" |
+| "Add freshness SLOs" | "Is there a defined expectation for when this data should be available?" |
+| "Classify all PII" | "If this data was leaked, what would be the impact?" |
+| "Implement lineage tracking" | "Can we trace this data back to its original source?" |
+
+**Rationale:** Questions guide the reviewer to investigate the code and form a judgement. Imperatives produce binary "present/absent" assessments that miss nuance.
+
+### 5.3 Concrete anti-patterns with code examples
+
+Anti-pattern descriptions include specific code-level examples (SQL, Python, dbt), not abstract categories.
+
+| Bad (abstract) | Good (concrete) |
+|-----------------|-----------------|
+| "Poor data quality" | "Silent type coercion: `pd.to_numeric(df['amount'], errors='coerce')` -- invalid values become NaN with no logging" |
+| "Schema issue" | "Breaking change: `ALTER TABLE users RENAME COLUMN user_name TO username` -- all downstream consumers break immediately" |
+| "Missing governance" | "PII in analytics: `df[['user_id', 'email', 'phone']].to_parquet('s3://analytics-bucket/')` -- raw PII in analytics layer" |
+
+### 5.4 Positive observations required
+
+Every review MUST include a "What's Good" section. Reviews that only list problems are demoralising and less actionable. Positive data patterns give teams confidence about what to preserve -- well-designed schemas, good test coverage, clear documentation, proper governance.
+
+### 5.5 Hygiene gate is consequence-based
+
+The Hygiene gate uses three consequence-severity tests (Irreversible, Total, Regulated), not domain-specific checklists. This ensures consistent escalation logic across all domains.
+
+### 5.6 Severity is about data impact
+
+| Level | Definition | Decision |
+|-------|-----------|----------|
+| **HIGH** | Data corruption, compliance violation, or consumer-breaking change | Must fix before merge |
+| **MEDIUM** | Quality degradation, performance issue, or missing documentation | May require follow-up ticket |
+| **LOW** | Style improvement or minor optimisation | Nice to have |
+
+Severity measures the **data consequence** if the code ships as-is -- how will consumers be affected, can trust be maintained, is compliance at risk. Not how hard the fix is.
+
+### 5.7 Consumer-first perspective
+
+Data reviews evaluate from the **consumer's perspective**. The primary question is always: "How will downstream consumers experience this data?"
+
+| Concern | Consumer perspective | Producer perspective (avoid) |
+|---------|---------------------|------------------------------|
+| Schema change | "Will this break my queries?" | "I needed to rename this column" |
+| Quality | "Can I trust these numbers?" | "The pipeline ran without errors" |
+| Freshness | "Is this data current enough for my decision?" | "The job runs every hour" |
+| Documentation | "Can I use this without asking someone?" | "The code is self-documenting" |
+
+### 5.8 Fail-safe defaults
+
+Data handling should be **explicit, not silent**. When a data pipeline encounters unexpected input, the correct behaviour is to fail visibly, not to silently drop or coerce records. Silent data loss is worse than a noisy failure because it erodes trust without anyone knowing.
+
+## 6. Orchestration Process
+
+The `/review-data` skill follows this process:
+
+### Step 1: Scope identification
+
+- File or directory argument: review that path
+- Empty or ".": review recent changes (`git diff`) or prompt for scope
+- Focus on: SQL files, Python/Spark data processing, dbt models, pipeline definitions, schema files, migration scripts
+
+### Step 2: Parallel dispatch
+
+Spawn 4 subagents simultaneously:
+
+| Agent | Model | Rationale |
+|-------|-------|-----------|
+| `data-architecture` | sonnet | Nuanced judgement on schema design, domain boundaries, and contract completeness |
+| `data-engineering` | sonnet | Complex analysis of transformation correctness, idempotency, and performance |
+| `data-quality` | sonnet | Subtle assessment of freshness, validation coverage, and documentation adequacy |
+| `data-governance` | sonnet | Nuanced compliance analysis, PII identification, lifecycle management assessment |
+
+**Model selection rationale:** All four Data agents use sonnet because data review requires nuanced judgement at every level. Unlike some SRE pillars where criteria are more binary, all data pillars require interpreting code against contextual quality expectations -- is this schema appropriate for the use case, is this transformation correct for the business logic, is this governance sufficient for the data classification.
+
+### Step 3: Synthesis
+
+1. **Collect** findings from all 4 pillars
+2. **Deduplicate** -- when two agents flag the same `file:line`, merge into one finding:
+   - Take the **highest severity**
+   - Take the **most restrictive maturity level** (HYG > L1 > L2 > L3)
+   - Combine recommendations from both agents
+   - Credit both pillars in the Pillar column (e.g., "Architecture / Quality")
+3. **Aggregate maturity** -- merge per-criterion assessments into one view:
+   - All criteria met = `pass`
+   - Mix of met and not met = `partial`
+   - All criteria not met = `fail`
+   - Previous level not passed = `locked`
+4. **Prioritise** -- HYG findings first, then by severity (HIGH > MEDIUM > LOW)
+
+### Step 4: Output
+
+Produce the maturity assessment report per the output format defined in `_base.md`.
+
+## 7. Improvement Vectors
+
+Known gaps that future work should address, in priority order:
+
+| # | Gap | Impact | Direction |
+|---|-----|--------|-----------|
+| 1 | **Quality Dimensions not explicitly mapped to pillars** | Reviewers don't systematically verify each quality dimension | Add explicit mapping: "this pillar is responsible for these quality dimensions" (see `framework-map.md`) |
+| 2 | **No calibration examples** | Severity judgements are inconsistent -- the same missing freshness SLO might be HIGH in one review and MEDIUM in another | Add worked examples per severity per pillar (see `calibration.md`) |
+| 3 | **L1 "sufficient" is undefined** | "Schemas are documented with field-level descriptions" is subjective -- what counts as sufficient documentation? | Define minimum thresholds (see `maturity-criteria.md`) |
+| 4 | **Decay Patterns not codified** | The analytical duality is implicit -- anti-patterns exist but aren't classified by decay mechanism | Formalise decay pattern taxonomy and map to quality dimension defences (see `framework-map.md`) |
+| 5 | **No technology-specific supplements** | Checklists can't recognise framework-specific patterns (dbt vs SQLMesh vs Airflow vs Spark) | Future: add optional supplements for dbt, Spark, Airflow, Dagster, BigQuery, Snowflake |
+| 6 | **Governance assessment is document-heavy** | Governance agent sometimes expects policy documents rather than looking for evidence in code | Refine to focus on code evidence: TTL columns, partition expiration, soft-delete flags, access controls in DDL |
+| 7 | **No streaming data patterns** | Checklists are batch-oriented; streaming-specific concerns (watermarks, late data, exactly-once semantics) are underrepresented | Future: add streaming supplement covering Kafka, Flink, event sourcing patterns |
+| 8 | **No cross-review learning** | Each review is stateless | Future: use `.code-review/` history to track data maturity progression |
+
+## 8. Constraints
+
+Things the Data domain deliberately does NOT do:
+
+- **No auto-fix.** The review is read-only. Agents have Read, Grep, Glob tools only -- no Bash, no Write, no Edit.
+- **No cross-domain findings.** Data does not flag architecture, SRE, or security issues. Those belong to their respective domains. Overlaps are intentional (e.g., PII handling is flagged by both Data/Governance and Security/Data-Protection, each through their own lens).
+- **No numeric scores.** Status is pass/partial/fail/locked. No percentages, no weighted scores, no "data quality index".
+- **No prescribing specific tools.** Never recommend a specific library, framework, or vendor. Describe the outcome, let the team choose the implementation. Say "input data is validated with automated checks", not "use Great Expectations".
+- **No prescribing specific modelling approaches.** Do not require "star schema" or "3NF" or "Data Vault". Describe the structural property the data should exhibit for its use case. The team may achieve it through any approach.
+- **No fabricating findings.** If a pillar doesn't apply (e.g., no PII in the reviewed code means Governance/Privacy has nothing to report), return "no findings" -- do not invent concerns to fill the report.


### PR DESCRIPTION
## Summary
- Add `spec/dat/spec.md` — the canonical Data domain specification using four pillars (Architecture, Engineering, Quality, Governance), quality dimensions vs decay patterns analytical duality (from DAMA DMBOK), and the maturity model
- Add 6 companion documents:
  - `glossary.md` — canonical definitions for all data terms, quality dimensions, and decay patterns
  - `framework-map.md` — how pillars, quality dimensions, and decay patterns interrelate
  - `maturity-criteria.md` — detailed criteria with "sufficient" thresholds per level
  - `calibration.md` — worked examples for severity and maturity judgement
  - `anti-patterns.md` — concrete code smells organised by pillar (SQL, Python, dbt examples)
  - `references.md` — source attribution for all frameworks and concepts
- Update `spec/README.md` to add the data spec index entry

## Test plan
- [ ] Verify spec structure: all companion files referenced in `spec.md` Section 3 exist
- [ ] Verify glossary covers all pillars, quality dimensions, and decay patterns
- [ ] Verify framework-map correctly links quality dimensions to decay patterns and pillars
- [ ] Verify maturity-criteria covers all four levels (Hygiene, L1, L2, L3) for each pillar
- [ ] Verify file layout in Section 4 matches the planned plugin directory structure
- [ ] Verify `spec/README.md` links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)