### PR TITLE
Add planning workflow with phase gates and prompt templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Milestone: "Code-Review Plugin v1"
 
 ```
 plan/{milestone-name}/
-├── SPEC.md                         ← Milestone-level: the what and why
+├── BRIEF.md                        ← Milestone-level brief: the what and why (transient)
 └── tasks/
     ├── 01-{issue-name}.tasks.md    ← Task list for Issue #1
     ├── 02-{issue-name}.tasks.md    ← Task list for Issue #2
@@ -54,14 +54,14 @@ Work follows three phases with hard gates between them. **You MUST NOT skip phas
 
 1. Follow the Socratic elicitation process in `spec/planning/spec.md` — ask clarifying questions until requirements are clear
 2. Create a GitHub Milestone for the work
-3. Write `plan/{milestone-name}/SPEC.md` — the what and why for the whole milestone
+3. Write `plan/{milestone-name}/BRIEF.md` — the what and why for the whole milestone (transient planning brief, not a permanent spec)
 4. Write one task file per issue in `plan/{milestone-name}/tasks/{NN}-{issue-name}.tasks.md`
 5. Create GitHub Issues (one per task file), linked to the Milestone
 6. **STOP.** Tell the user: "Planning complete. Review the milestone, issues, and task files. When ready, use EXECUTE.prompt.md to begin implementation."
 
 **What planning produces:**
 
-- `plan/{milestone-name}/SPEC.md` — milestone-level specification
+- `plan/{milestone-name}/BRIEF.md` — milestone-level planning brief
 - `plan/{milestone-name}/tasks/*.tasks.md` — one task file per issue
 - GitHub Milestone with linked Issues
 - NO code, NO feature branches, NO file changes outside `plan/`
@@ -73,7 +73,7 @@ Work follows three phases with hard gates between them. **You MUST NOT skip phas
 
 1. Read the specified task file (e.g., `plan/{milestone}/tasks/01-sre.tasks.md`)
 2. Find the next unchecked `- [ ]` task
-3. Read the task's spec references and context
+3. Read the task's brief references and any referenced standards
 4. Execute the task (create branch if first task, write code, verify)
 5. Mark the task `- [x]` in the task file
 6. **STOP.** Report what was done. The next invocation picks up the next task.
@@ -108,7 +108,7 @@ The user then moves to the next task file (next issue) or reviews the PR first.
 - **Stateless agents.** Each execution reads state from files, not from conversation history.
 - **Reviewable.** The user can review, edit, and reorder tasks before execution begins.
 - **Right-sized PRs.** One PR per issue is reviewable. One PR per milestone is not.
-- **Reproducible.** Given the same SPEC.md and task files, the work can be re-executed.
+- **Reproducible.** Given the same BRIEF.md and task files, the work can be re-executed.
 - **Plans are transient, specs are permanent.** Plans drive execution; specs capture the lasting knowledge. After a milestone completes, learnings migrate to `spec/` and the plan directory is deleted.
 
 ## Git Workflow

--- a/EXECUTE.prompt.md
+++ b/EXECUTE.prompt.md
@@ -7,7 +7,7 @@ You work on **one task file** (one issue) at a time. Each task file maps to one 
 ## Your Constraints
 
 - You ONLY work on the **next unchecked task** in the specified task file
-- You MUST read the task's spec references before writing any code
+- You MUST read the task's brief references and standards before writing any code
 - You MUST NOT skip tasks or work on multiple tasks at once
 - You MUST NOT work across task files (issues) — each invocation targets one file
 - You MUST mark the task as done in the task file when complete
@@ -18,10 +18,10 @@ You work on **one task file** (one issue) at a time. Each task file maps to one 
 ### Step 1: Load Context
 
 1. Read the specified task file (e.g., `plan/{milestone}/tasks/01-sre.tasks.md`)
-2. Read the task file header: **Issue**, **Branch**, **Depends on**, **Spec ref**
+2. Read the task file header: **Issue**, **Branch**, **Depends on**, **Brief ref**
 3. Find the first task marked `- [ ]` (unchecked)
-4. Read the task's **Spec ref** section(s) from `plan/{milestone}/SPEC.md`
-5. Read any **Standards** files referenced by the task
+4. Read the task's **Brief ref** section(s) from `plan/{milestone}/BRIEF.md` (the transient planning brief)
+5. Read any **Standards** files referenced by the task (permanent specs under `spec/`)
 6. If the task references existing code, read those files
 
 If ALL tasks in this file are marked `- [x]`, go to **Step 5: Issue Completion**.
@@ -82,10 +82,10 @@ Next issue: {next task file name} (or "all issues complete")
 When the task file being processed is the **close-out issue** (`{NN}-close.tasks.md`) and all its tasks are `- [x]`:
 
 1. **Verify** all other milestone issues are closed and PRs merged
-2. **Spec updates** have been completed by earlier tasks in this file:
+2. **Spec updates** have been completed by earlier tasks in this file (rationale extracted from `BRIEF.md`, written to permanent `spec/` files):
    - New patterns added to relevant spec files
    - Decision rationale captured (trade-offs, alternatives, constraints)
-   - Spec divergences reconciled (specs match implemented reality)
+   - Divergences reconciled (specs match implemented reality, not the original brief)
    - New vocabulary added to glossaries
    - `spec/README.md` index updated
 3. **Plan directory deleted** by earlier task in this file

--- a/PLAN.prompt.md
+++ b/PLAN.prompt.md
@@ -8,7 +8,7 @@ You are the **Architect-Prime** — a Principal Architect and Technical Product 
 
 - You MUST NOT create, modify, or delete any implementation files (source code, configs, scripts)
 - You MUST NOT create feature branches
-- You ONLY produce: `SPEC.md`, task files (`*.tasks.md`), GitHub Milestone, GitHub Issues
+- You ONLY produce: `BRIEF.md`, task files (`*.tasks.md`), GitHub Milestone, GitHub Issues
 - You STOP after producing these artifacts and wait for the user to review
 
 ## Hierarchy
@@ -40,11 +40,11 @@ Follow `spec/planning/spec.md` Phase 1. Ask 3-5 clarifying questions covering:
 
 Iterate until you have a "Definition of Ready." Do NOT proceed until the user confirms requirements are clear.
 
-### Step 3: Create the Spec
+### Step 3: Create the Brief
 
-Write `plan/{milestone-name}/SPEC.md` following the format in `spec/planning/spec.md` Phase 2, Artifact 1.
+Write `plan/{milestone-name}/BRIEF.md` following the format in `spec/planning/spec.md` Phase 2, Artifact 1.
 
-This is the **milestone-level** specification — the what and why for the whole deliverable.
+This is the **milestone-level planning brief** — the what and why for the whole deliverable. It is a transient document that drives execution; permanent knowledge lives in `spec/`. The brief is deleted at milestone close-out.
 
 ### Step 4: Identify Issues (Phases)
 
@@ -61,7 +61,7 @@ For each issue, determine:
 - **Dependencies** — which other issues must complete first
 - **Deliverables** — what files/changes it produces
 
-Document the issue sequence in `SPEC.md`. The **last issue** must always be a close-out issue that updates specs and cleans up the plan:
+Document the issue sequence in `BRIEF.md`. The **last issue** must always be a close-out issue that updates specs and cleans up the plan:
 
 ```markdown
 ## Issue Sequence
@@ -87,13 +87,14 @@ Each task file has this format:
 **Issue:** #{number} (filled in after GitHub issue is created)
 **Branch:** feat/{issue-name}
 **Depends on:** #{other-issue-numbers} or "none"
-**Spec ref:** SPEC.md Section {N}
+**Brief ref:** BRIEF.md Section {N}
 
 ## Tasks
 
 - [ ] **TASK-01: {Name}**
   - **Goal:** {Actionable verb + outcome}
-  - **Spec ref:** SPEC.md Section {N.M}
+  - **Brief ref:** BRIEF.md Section {N.M}
+  - **Standards:** {permanent spec files to consult, e.g. spec/sre/spec.md} (optional)
   - **Files:** {files to create or modify}
   - **Verification:** {how the agent knows it worked}
 
@@ -109,7 +110,7 @@ Task decomposition rules:
 
 - **Atomicity** — Each task completable by a stateless agent in one turn (~200 lines or one module)
 - **Sequencing** — Ordered by dependency within the issue
-- **Context injection** — Each task references the specific SPEC.md section it implements
+- **Context injection** — Each task references the specific BRIEF.md section it implements, plus any permanent `spec/` standards it should consult
 - **Verification** — Each task defines how the agent knows it's done
 - **Self-contained** — Each task lists the files it creates/modifies so the agent doesn't have to guess
 
@@ -123,7 +124,7 @@ The **last task file** in every milestone MUST be `{NN}-close.tasks.md`. This is
 **Issue:** #{number}
 **Branch:** chore/close-{milestone-name}
 **Depends on:** all other issues in this milestone
-**Spec ref:** SPEC.md (entire document)
+**Brief ref:** BRIEF.md (entire document — read as source material before updating specs)
 
 ## Tasks
 
@@ -132,11 +133,11 @@ The **last task file** in every milestone MUST be `{NN}-close.tasks.md`. This is
   - **Verification:** Each new pattern has a section in the appropriate spec file
 
 - [ ] **TASK-02: Capture decision rationale**
-  - **Goal:** Document why key design choices were made — trade-offs considered, alternatives rejected, constraints that drove decisions — in the relevant spec files under `spec/`
-  - **Verification:** Each significant decision from SPEC.md has rationale captured in a spec file
+  - **Goal:** Extract rationale from `BRIEF.md` and implementation experience — trade-offs considered, alternatives rejected, constraints that drove decisions — and add to the relevant spec files under `spec/`
+  - **Verification:** Each significant decision from BRIEF.md has rationale captured in a spec file
 
 - [ ] **TASK-03: Reconcile spec divergences**
-  - **Goal:** Where implementation intentionally diverged from the original spec, update the spec to match reality
+  - **Goal:** Where implementation intentionally diverged from the planning brief, update the permanent specs under `spec/` to match reality
   - **Verification:** No contradictions between specs and implemented code
 
 - [ ] **TASK-04: Add new vocabulary**
@@ -175,7 +176,7 @@ Tell the user:
 Planning complete.
 
 Milestone: {milestone name} ({url})
-Spec: plan/{milestone-name}/SPEC.md
+Brief: plan/{milestone-name}/BRIEF.md
 Issues:
   #{N}: {title} → {NN}-{name}.tasks.md ({X} tasks)
   #{N}: {title} → {NN}-{name}.tasks.md ({X} tasks)


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Adds mandatory three-phase workflow (Plan → Execute → Complete) with hard gates. Planning phase produces files and GitHub issues only — no implementation code. Execution phase works from `TASKS.md` one task at a time.
- **PLAN.prompt.md**: Planning-only prompt template. Constrains Claude to Socratic elicitation → SPEC.md → TASKS.md → Milestone/Issues → STOP.
- **EXECUTE.prompt.md**: Execution prompt template. Reads next unchecked task from TASKS.md, executes it, marks done, stops. Includes Ralph Wiggum loop script for automated execution.

## Why

Plans held only in conversation context are lost on compaction. This workflow persists plans to files (`plan/{feature}/SPEC.md`, `TASKS.md`) and GitHub artifacts (Milestone, Issues) so that:
- Plans survive context window limits
- Each agent invocation is stateless (reads state from files)
- Plans are reviewable and editable before execution begins
- Work is reproducible given the same SPEC and TASKS

## Test plan

- [ ] Verify CLAUDE.md renders correctly and phase gates are unambiguous
- [ ] Verify PLAN.prompt.md can be used to produce a plan without triggering implementation
- [ ] Verify EXECUTE.prompt.md loop script syntax is correct
- [ ] Test end-to-end: use PLAN.prompt.md for a small feature, review output, then use EXECUTE.prompt.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)