### PR TITLE
Promote execution agent to coordination role

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A Code Review Plugin for Claude Code that enables generalist software engineers to extend their review capability across Architecture, Security, Site Reliability Engineering (SRE), and Data Engineering disciplines. The plugin provides slash commands (`review-all`, `review-sec`, `review-sre`, `review-arch`, `review-data`) that perform domain-specific code reviews with progressive level reporting.
 
+## Markdown standards
+
+- Use British English.
+- One sentence per line.
+- One line per sentence.
+- Headings have blank line under them
+- Ordered and unordered lists have a blank line before and after them
+
 ## Work Hierarchy
 
 All non-trivial work is organised in three levels:
 
-```
+```text
 Milestone          → The deliverable (what stakeholders care about)
   └── Issue        → A phase of work producing a reviewable, mergeable unit (1 Issue = 1 PR)
         └── Task   → An atomic unit a stateless agent can complete in one turn
@@ -18,7 +26,7 @@ Milestone          → The deliverable (what stakeholders care about)
 
 **Example:**
 
-```
+```text
 Milestone: "Code-Review Plugin v1"
 ├── Issue #1: Create SRE code review        → PR: feat/sre-domain → closes #1
 │   ├── TASK-01: Create SRE base prompt
@@ -32,7 +40,7 @@ Milestone: "Code-Review Plugin v1"
 
 ### File structure for plans
 
-```
+```text
 plan/{milestone-name}/
 ├── BRIEF.md                        ← Milestone-level brief: the what and why (transient)
 └── tasks/
@@ -73,7 +81,7 @@ Work follows three phases with hard gates between them. **You MUST NOT skip phas
 
 1. Read the specified task file (e.g., `plan/{milestone}/tasks/01-sre.tasks.md`)
 2. Find the next unchecked `- [ ]` task
-3. Read the task's brief references and any referenced standards
+3. Read the task's brief references
 4. Execute the task (create branch if first task, write code, verify)
 5. Mark the task `- [x]` in the task file
 6. **STOP.** Report what was done. The next invocation picks up the next task.

--- a/EXECUTE.prompt.md
+++ b/EXECUTE.prompt.md
@@ -1,8 +1,9 @@
 # Execution Prompt
 
-You are an **Implementation Agent** executing tasks from a pre-approved plan.
+You are an **Implementation Coordination Agent** executing tasks from a pre-approved plan.
 
-You work on **one task file** (one issue) at a time. Each task file maps to one GitHub Issue, one branch, and one PR.
+You work on **one task file** (one issue) at a time.
+Each task file maps to one GitHub Issue, one branch, and one PR.
 
 ## Your Constraints
 
@@ -21,7 +22,7 @@ You work on **one task file** (one issue) at a time. Each task file maps to one 
 2. Read the task file header: **Issue**, **Branch**, **Depends on**, **Brief ref**
 3. Find the first task marked `- [ ]` (unchecked)
 4. Read the task's **Brief ref** section(s) from `plan/{milestone}/BRIEF.md` (the transient planning brief)
-5. Read any **Standards** files referenced by the task (permanent specs under `spec/`)
+5. Study ./spec/README.md and relevant domain specs in `spec/` referenced by the brief
 6. If the task references existing code, read those files
 
 If ALL tasks in this file are marked `- [x]`, go to **Step 5: Issue Completion**.
@@ -34,9 +35,9 @@ If ALL tasks in this file are marked `- [x]`, go to **Step 5: Issue Completion**
 
 ### Step 3: Execute
 
-1. Implement the task as described
+1. You are the coordination agent for the task. Delegate implementation to subagents using the Task tool. Use subagents for: writing code, running verification, and reviewing the output against the spec. Pass relevant context and instructions to each subagent. Synthesise their results and resolve any conflicts.
 2. Run the task's **Verification** step (test, lint, validate, etc.)
-3. If verification fails, fix the issue and re-verify
+3. If verification fails, get the team of agents to fix the issue and re-verify. Continue until it passes.
 4. Commit the work with a descriptive message referencing the task ID and issue number
 
 ### Step 4: Mark Done and STOP

--- a/PLAN.prompt.md
+++ b/PLAN.prompt.md
@@ -94,7 +94,6 @@ Each task file has this format:
 - [ ] **TASK-01: {Name}**
   - **Goal:** {Actionable verb + outcome}
   - **Brief ref:** BRIEF.md Section {N.M}
-  - **Standards:** {permanent spec files to consult, e.g. spec/sre/spec.md} (optional)
   - **Files:** {files to create or modify}
   - **Verification:** {how the agent knows it worked}
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Describe any configuration options here.
 
 ### Planning
 
-Start an interactive planning session. The agent follows `PLAN.prompt.md` — Socratic elicitation, BRIEF.md, task files, GitHub Milestone and Issues. No code is written.
+Start an interactive planning session.
+The agent follows `PLAN.prompt.md` using Socratic elicitation to generate a plan folder with a master _BRIEF.md_ and specific task files.
+A GitHub Milestone for the planned work with each task file having a target GitHub Issue.
+No code is written.
 
 ```bash
 ./scripts/plan.sh
@@ -60,7 +63,7 @@ Start an interactive planning session. The agent follows `PLAN.prompt.md` — So
 
 Or interactively in Claude Code:
 
-```
+```claude
 Follow PLAN.prompt.md
 ```
 
@@ -68,7 +71,7 @@ Follow PLAN.prompt.md
 
 **Run a single task** (interactive, one at a time):
 
-```
+```claude
 Follow EXECUTE.prompt.md for plan/{milestone}/tasks/01-scaffolding.tasks.md
 ```
 
@@ -101,6 +104,7 @@ Guidelines for contributing to this project.
 ## Authors
 
 - Lee Campbell [LeeCampbell.com](https://leecampbell.com)
+- Claude Code with Opus 4.6
 
 ## Support
 


### PR DESCRIPTION
## Summary

- Rename execution agent to **Implementation Coordination Agent** — delegates to subagents via Task tool rather than doing everything inline
- Spec discovery now via `spec/README.md` instead of per-task `Standards` field
- Remove redundant `Standards` field from task file template in PLAN.prompt.md
- Align CLAUDE.md Phase 2 description with new model
- Add markdown standards section to CLAUDE.md
- Minor README improvements

## Test plan

- [ ] Verify EXECUTE.prompt.md instructs coordination via subagents
- [ ] Verify PLAN.prompt.md task template no longer has Standards field
- [ ] Verify CLAUDE.md Phase 2 no longer references "standards"
- [ ] Verify no orphaned references to the removed Standards field

🤖 Generated with [Claude Code](https://claude.com/claude-code)