### PR TITLE
Prefer git checkout over git stash in workflow guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ The user then moves to the next task file (next issue) or reviews the PR first.
 
 - **Never commit directly to `main`** — pre-commit and pre-push hooks enforce this
 - Create feature branches: `git checkout -b feat/<description>`
-- Push feature branches and create PRs against `main`
+- Push feature branches and create PRs against `main`. Prefer `git checkout -b <branch> <base>` to carry uncommitted work to a new branch; avoid using `git stash` if possible.
 - Branch naming convention: `feat/`, `fix/`, `chore/` prefixes
 - **One branch per issue.** Each task file declares its branch name. All tasks within an issue are committed to the same branch.
 


### PR DESCRIPTION
## Summary

- Adds guidance to CLAUDE.md Git Workflow section to prefer `git checkout -b <branch> <base>` over `git stash` when switching branches with uncommitted work
- Prevents agents from repeatedly using stash (which fails with untracked file conflicts and risks losing work)

## Test plan

- [ ] Verify CLAUDE.md renders correctly
- [ ] Verify agents follow the guidance in future sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)