### PR TITLE
Add planning artifacts for Code Review Plugin v1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Work follows three phases with hard gates between them. **You MUST NOT skip phas
 **Trigger:** User asks you to plan, design, or implement a feature.
 **Constraint:** Do NOT write implementation code. Do NOT create feature branches. Only produce planning artifacts.
 
-1. Follow the Socratic elicitation process in `spec/planning/spec.md` — ask clarifying questions until requirements are clear
+1. Follow the Socratic elicitation process in `PLAN.prompt.md` Step 2 — ask clarifying questions until requirements are clear
 2. Create a GitHub Milestone for the work
 3. Write `plan/{milestone-name}/BRIEF.md` — the what and why for the whole milestone (transient planning brief, not a permanent spec)
 4. Write one task file per issue in `plan/{milestone-name}/tasks/{NN}-{issue-name}.tasks.md`
@@ -135,7 +135,7 @@ When planning work:
 - Create GitHub Issues to define specific outcomes related to a Milestone
 - If the work is not large enough for its own Milestone, ask which milestone it should belong to, or create a "v next" milestone
 - Once planning is complete, the plan lives in `plan/{milestone-name}/` — NOT in conversation memory
-- Use `spec/planning/spec.md` to guide the Socratic elicitation and artifact generation process
+- Use `PLAN.prompt.md` to guide the Socratic elicitation and artifact generation process
 
 ## Specifications
 

--- a/PLAN.prompt.md
+++ b/PLAN.prompt.md
@@ -30,7 +30,7 @@ Read the user's request. Then read relevant specifications:
 
 ### Step 2: Socratic Elicitation
 
-Follow `spec/planning/spec.md` Phase 1. Ask 3-5 clarifying questions covering:
+Ask 3-5 clarifying questions covering:
 
 1. **Ambiguity** — Are there undefined terms or vague requirements?
 2. **Standards alignment** — Does this conflict with existing specs or patterns?

--- a/Planner.md
+++ b/Planner.md
@@ -2,38 +2,156 @@
 
 ## Context
 
-We're building a Claude Code Plugin Marketplace for the `donkey-developer` GitHub org. The first plugin is `code-review`, providing domain-specific code reviews across Architecture, Security, SRE, and Data Engineering. The specs (39 files, ~6,600 lines) are complete; zero implementation exists. This plan covers the full v1.0 implementation.
+We are building a Claude Code Plugin Marketplace for the `donkey-developer` GitHub org.
+The first plugin is `code-review`, providing domain-specific code reviews across Architecture, Security, SRE, and Data Engineering.
+The specs (39 files, ~6,600 lines) are complete; zero implementation exists.
+This plan covers the full v1.0 implementation.
 
-The repo will be renamed from `code-review-plugin` to `claude-plugins` to reflect its role as a marketplace containing multiple plugins over time.
+## Spike Repository
+
+The spike repo at `https://github.com/LeeCampbell/code-review-llm` contains a prior implementation that originated this plugin idea.
+That repo tried to do too many things, so the plugin work has been extracted to live here in `donkey-developer/claude-plugins`.
+
+The spike repo structure under `.claude/` serves as a **cross-reference** for structure, tone, and content:
+
+- `.claude/prompts/{domain}/_base.md` + `{pillar}.md` — prompt source files
+- `.claude/agents/{domain}-{pillar}.md` — compiled agent files
+- `.claude/skills/review-{domain}/SKILL.md` — skill orchestrators
+
+**The specs in this repo are authoritative.**
+Where the spike repo and the specs disagree, follow the specs.
 
 ## Key Architecture Decisions
 
 ### Plugin model
+
 - **Marketplace repo**: `donkey-developer/claude-plugins`
 - **Plugin name**: `code-review` → commands are `/code-review:sre`, `/code-review:all`, etc.
 - **Install flow**: `/plugin marketplace add donkey-developer/claude-plugins` then `/plugin install code-review@donkey-developer`
 
 ### Three-tier file structure (per `spec/review-standards/review-framework.md` lines 17-41)
+
 ```
 plugins/code-review/
-├── skills/{domain}/SKILL.md      ← Orchestrators (user-triggered, dispatch + synthesize)
+├── skills/{domain}/SKILL.md      ← Orchestrators (user-triggered, dispatch + synthesise)
 ├── agents/{domain}-{pillar}.md   ← Self-contained subagents (16 total, inlined prompts)
 └── prompts/                      ← Source of truth (human-editable, NOT read at runtime)
-    ├── shared/                   ← Cross-domain content
+    ├── shared/                   ← Cross-domain content (including synthesis rules)
     └── {domain}/                 ← Domain + pillar content
 ```
 
 ### Composition model (per spec composition rules)
+
 - **Agents are self-contained.** Each agent file inlines all context it needs (shared + domain base + pillar). Agents do NOT read external files at runtime.
 - **Prompts are the source of truth.** The `prompts/` directory is human-editable source. Agent files are "compiled" from prompts.
-- **Compilation for v1.0 is manual.** When a prompt changes, the corresponding agent file(s) must be updated. A build script can be added later.
+- **Skills are compiled from prompts too.** Each SKILL.md inlines the shared synthesis rules from `prompts/shared/synthesis.md` plus any domain-specific synthesis additions from the domain's `_base.md`. This ensures standalone domain reviews and `/code-review:all` produce identical domain reports.
+- **Compilation is automated.** A build script (`scripts/compile.sh`) generates all agent and skill files from prompts. Agent and skill files are NEVER hand-edited. A pre-commit hook validates that generated files are in sync with their prompt sources.
 
 ### Skill naming (full domain names with code-review prefix)
+
 - `skills/all/SKILL.md` → `/code-review:all`
 - `skills/sre/SKILL.md` → `/code-review:sre`
 - `skills/security/SKILL.md` → `/code-review:security`
 - `skills/architecture/SKILL.md` → `/code-review:architecture`
 - `skills/data/SKILL.md` → `/code-review:data`
+
+### Agent configuration
+
+Each agent uses this frontmatter pattern:
+
+```yaml
+---
+name: {domain}-{pillar}
+description: {One-line description}. Spawned by /code-review:{domain} or /code-review:all.
+model: {sonnet or haiku, per domain spec recommendation}
+tools: Read, Grep, Glob
+---
+```
+
+- **tools: Read, Grep, Glob** — agents are explicitly read-only per spec constraint "No auto-fix."
+- **model** — follows each domain's spec recommendation:
+  - SRE: sonnet for Response, Observability, Availability; haiku for Delivery
+  - Security: sonnet for AuthN/AuthZ, Data Protection, Input Validation; haiku for Audit & Resilience
+  - Architecture: sonnet for all 4 (Code, Service, System, Landscape)
+  - Data: sonnet for all 4 (Architecture, Engineering, Quality, Governance)
+
+### Skill orchestrator configuration
+
+Each domain skill uses this frontmatter pattern:
+
+```yaml
+---
+name: {domain}
+description: {Domain name} code review across {list of pillars}.
+argument-hint: [path|PR#|.]
+allowed-tools: Task, Read, Grep, Glob, Bash, Write
+---
+```
+
+- `Task` — to spawn pillar agents in parallel
+- `Read, Grep, Glob` — for scope detection and file discovery
+- `Bash` — for `git diff`, `gh pr diff`, `mkdir`
+- `Write` — to write the output report
+
+### Compilation pipeline
+
+Agent files and skill files are generated from prompts by `scripts/compile.sh`.
+This ensures prompts remain the single source of truth and prevents drift between prompts and their compiled outputs.
+
+**What the compile script produces:**
+
+- 16 agent files in `agents/` — each compiled from: shared prompts + domain `_base.md` + pillar prompt + review instructions
+- 5 skill files in `skills/` — each compiled from: skill template + `synthesis.md` + domain synthesis additions
+
+**Where agent metadata lives:**
+
+- `prompts/compile.conf` — maps each agent to its model and one-line description
+- Each domain's `_base.md` — contains a `## Review Instructions` section with the domain-specific attack/defence lens names (e.g., SEEMS/FaCTOR for SRE, STRIDE Threats/Security Properties for Security)
+
+**Dependency graph** (derived from naming conventions):
+
+- `agents/{domain}-{pillar}.md` depends on: `prompts/shared/*` + `prompts/{domain}/_base.md` + `prompts/{domain}/{pillar}.md` + `prompts/compile.conf`
+- `skills/{domain}/SKILL.md` depends on: `prompts/shared/synthesis.md` + `prompts/{domain}/_base.md` + `prompts/compile.conf`
+- `skills/all/SKILL.md` depends on: `prompts/shared/synthesis.md` + all domain `_base.md` files + `prompts/compile.conf`
+
+**Pre-commit hook:**
+
+- Runs `scripts/compile.sh` in check mode
+- Compares generated output against committed agent/skill files
+- Fails the commit if any file is out of sync, with a message to run `scripts/compile.sh`
+
+**Workflow for changing a prompt:**
+
+1. Edit the prompt file(s) in `prompts/`
+2. Run `scripts/compile.sh`
+3. Commit both the prompt changes and the regenerated agent/skill files
+4. The pre-commit hook verifies consistency
+
+### code-review:all dispatch strategy
+
+The `:all` skill dispatches **16 agents directly** (flat dispatch), not 4 domain skills nested.
+
+**Rationale:** Subagents cannot spawn other subagents (Claude Code platform constraint).
+If `:all` invoked domain skills inline, they would run sequentially (one domain at a time), accumulating all intermediate results in the main conversation context.
+With 16+ agents of review output, this risks context window exhaustion — especially as UX and Product domains are added later.
+
+Flat dispatch spawns all 16 agents in parallel.
+Each agent runs in its own context window.
+Only summarised results return to the parent, keeping context manageable.
+
+**Synthesis consistency:** Both standalone domain skills and `:all` compile their synthesis logic from the same source: `prompts/shared/synthesis.md` + domain-specific additions from each `_base.md`.
+This ensures `/code-review:sre` and `/code-review:all` produce identical SRE domain reports.
+
+The `:all` skill workflow:
+
+1. Scope detection (same algorithm as domain skills)
+2. Batch naming
+3. Output dir: `mkdir -p .code-review/<batch-name>/`
+4. Dispatch: spawn 16 agents in parallel via Task tool, passing scope
+5. Collect: gather results from all 16 agents
+6. Synthesise per domain: group by domain (4 groups of 4), apply `synthesis.md` rules + domain-specific pre-filters, write domain report
+7. Write cross-domain summary: `.code-review/<batch-name>/summary.md`
+8. Report: summary to user with finding counts and file paths
 
 ## Target Directory Structure
 
@@ -71,13 +189,17 @@ claude-plugins/                              ← Marketplace repo root
 │       │   ├── data-engineering.md
 │       │   ├── data-quality.md
 │       │   └── data-governance.md
+│       ├── scripts/
+│       │   └── compile.sh                   ← Generates agents/ and skills/ from prompts/
 │       └── prompts/                         ← Human-editable source (not read at runtime)
+│           ├── compile.conf                 ← Agent metadata: name, model, description
 │           ├── shared/
 │           │   ├── maturity-model.md        ← Hygiene gate, L1/L2/L3, status indicators
 │           │   ├── severity-framework.md    ← HIGH/MEDIUM/LOW definitions
 │           │   ├── design-principles.md     ← 5 core principles
 │           │   ├── output-format.md         ← Finding table, maturity table, sections
-│           │   └── constraints.md           ← Read-only, no cross-domain, no scores
+│           │   ├── constraints.md           ← Read-only, no cross-domain, no scores
+│           │   └── synthesis.md             ← Dedup, aggregate maturity, prioritise
 │           ├── sre/
 │           │   ├── _base.md                 ← ROAD, SEEMS/FaCTOR, maturity criteria, glossary
 │           │   ├── response.md              ← RP-01..RP-06 anti-patterns + checklist
@@ -110,120 +232,120 @@ claude-plugins/                              ← Marketplace repo root
 
 ### Milestone: "Code Review Plugin v1.0"
 
+Each issue maps to exactly one PR (1 issue = 1 branch = 1 PR).
+
 ### Phase 0: Scaffolding (1 issue, 1 PR)
 
-| Issue | Title | Deliverables |
-|-------|-------|-------------|
-| #1 | Rename repo and create marketplace + plugin scaffolding | `marketplace.json`, `plugin.json`, directory structure, updated CLAUDE.md/README.md, `.gitignore` for `.code-review/` |
+| Title | Branch | Deliverables |
+|-------|--------|-------------|
+| Create marketplace and plugin scaffolding | `chore/marketplace-scaffolding` | `marketplace.json`, `plugin.json`, directory structure, `scripts/compile.sh`, `prompts/compile.conf`, pre-commit hook, updated README.md, `.gitignore` for `.code-review/` |
 
 ### Phase 1: Shared Prompts (1 issue, 1 PR)
 
-| Issue | Title | Files |
-|-------|-------|-------|
-| #2 | Create shared cross-domain prompts | All 5 files in `prompts/shared/` |
+| Title | Branch | Files |
+|-------|--------|-------|
+| Create shared cross-domain prompts | `feat/shared-prompts` | All 6 files in `prompts/shared/` |
 
 Sources: `spec/review-standards/review-framework.md`, `spec/review-standards/design-principles.md`, `spec/review-standards/orchestration.md`
 
-### Phase 2: SRE Domain — Reference Implementation (2 issues, 1 PR)
+### Phase 2: Domain Reviews (4 issues, 4 PRs)
 
-SRE is built first as the template for the other 3 domains.
+SRE is the **reference implementation** — built first to establish the pattern for the other 3 domains.
 
-| Issue | Title | Files |
-|-------|-------|-------|
-| #3 | Create SRE prompts (base + 4 pillars) | `prompts/sre/_base.md`, `prompts/sre/{response,observability,availability,delivery}.md` |
-| #4 | Create SRE agents (4) and skill orchestrator | `agents/sre-{response,observability,availability,delivery}.md`, `skills/sre/SKILL.md` |
+| Title | Branch | Files |
+|-------|--------|-------|
+| Create SRE domain review | `feat/sre-domain` | `prompts/sre/_base.md` + 4 pillar prompts → `compile.sh` generates `agents/sre-*.md` (4) + `skills/sre/SKILL.md` |
+| Create Security domain review | `feat/security-domain` | `prompts/security/_base.md` + 4 pillar prompts → `compile.sh` generates `agents/security-*.md` (4) + `skills/security/SKILL.md` |
+| Create Architecture domain review | `feat/architecture-domain` | `prompts/architecture/_base.md` + 4 pillar prompts → `compile.sh` generates `agents/architecture-*.md` (4) + `skills/architecture/SKILL.md` |
+| Create Data domain review | `feat/data-domain` | `prompts/data/_base.md` + 4 pillar prompts → `compile.sh` generates `agents/data-*.md` (4) + `skills/data/SKILL.md` |
 
-Sources: `spec/domains/sre/spec.md`, `spec/domains/sre/glossary.md`, `spec/domains/sre/framework-map.md`, `spec/domains/sre/maturity-criteria.md`, `spec/domains/sre/anti-patterns.md`, `spec/domains/sre/calibration.md`
+**Domain sources** (same pattern for each domain, substitute `{domain}`):
 
-Cross-check: `code-review-llm/.claude/prompts/sre/`, `code-review-llm/.claude/agents/sre-*.md`, `code-review-llm/.claude/skills/sre/SKILL.md`
+- `spec/domains/{domain}/spec.md` — domain specification index
+- `spec/domains/{domain}/anti-patterns.md` — anti-patterns with code examples
+- `spec/domains/{domain}/maturity-criteria.md` — domain-specific maturity criteria
+- `spec/domains/{domain}/framework-map.md` — framework mapping
+- `spec/domains/{domain}/glossary.md` — domain-specific terms
+- `spec/domains/{domain}/calibration.md` — calibration guidance
 
-### Phase 2: Security Domain (2 issues, 1 PR)
+**Cross-reference** (same pattern for each domain, substitute `{domain}` and `{pillar}`):
 
-| Issue | Title | Files |
-|-------|-------|-------|
-| #5 | Create Security prompts (base + 4 pillars) | `prompts/security/_base.md`, `prompts/security/{authn-authz,data-protection,input-validation,audit-resilience}.md` |
-| #6 | Create Security agents (4) and skill orchestrator | `agents/security-*.md`, `skills/security/SKILL.md` |
+- `https://github.com/LeeCampbell/code-review-llm` → `.claude/prompts/{domain}/_base.md` + `.claude/prompts/{domain}/{pillar}.md`
+- `https://github.com/LeeCampbell/code-review-llm` → `.claude/agents/{domain}-{pillar}.md`
+- `https://github.com/LeeCampbell/code-review-llm` → `.claude/skills/review-{domain}/SKILL.md`
 
-Domain-specific: confidence thresholds, exploit scenarios required, exclusion list, Tampering boundary rule.
+**Domain-specific notes:**
 
-### Phase 2: Architecture Domain (2 issues, 1 PR)
-
-| Issue | Title | Files |
-|-------|-------|-------|
-| #7 | Create Architecture prompts (base + 4 zoom levels) | `prompts/architecture/_base.md`, `prompts/architecture/{code,service,system,landscape}.md` |
-| #8 | Create Architecture agents (4) and skill orchestrator | `agents/architecture-*.md`, `skills/architecture/SKILL.md` |
-
-Domain-specific: zoom-level scaling ("no findings" is valid for smaller projects), design-time focus.
-
-### Phase 2: Data Domain (2 issues, 1 PR)
-
-| Issue | Title | Files |
-|-------|-------|-------|
-| #9 | Create Data prompts (base + 4 pillars) | `prompts/data/_base.md`, `prompts/data/{architecture,engineering,quality,governance}.md` |
-| #10 | Create Data agents (4) and skill orchestrator | `agents/data-*.md`, `skills/data/SKILL.md` |
-
-Domain-specific: consumer-first perspective, L2 has 5 criteria (not 4), data-specific file scoping (SQL, dbt, Spark).
+- **SRE:** ROAD framework, SEEMS/FaCTOR duality. No special synthesis rules beyond the common algorithm.
+- **Security:** STRIDE framework, threat/property duality. Confidence thresholds (remove findings below 50% confidence before deduplication). Exploit scenarios required for each finding. Explicit exclusion list (dependency scanning, secret scanning handled by dedicated tools). Tampering boundary rule (must be within code boundary, not infrastructure).
+- **Architecture:** C4 zoom levels, principles/erosion duality. Zoom-level scaling — "no findings" is valid for smaller projects at higher zoom levels. Design-time focus (evaluates decisions, not just implementation). Do NOT prescribe specific patterns by name.
+- **Data:** 4 Pillars, quality dimensions/decay patterns duality. Consumer-first perspective. L2 has 5 criteria (not 4). Data-specific file scoping (SQL, dbt, Spark, pipeline configs). Do NOT prescribe specific modelling approaches.
 
 ### Phase 3: Review-All Orchestrator (1 issue, 1 PR)
 
-| Issue | Title | Files |
-|-------|-------|-------|
-| #11 | Create code-review:all orchestrator | `skills/all/SKILL.md` |
+| Title | Branch | Files |
+|-------|--------|-------|
+| Create code-review:all orchestrator | `feat/code-review-all` | `skills/all/SKILL.md` |
 
-Implements: scope detection, batch naming, parallel dispatch of 4 domain skills, collection of sub-reports, summary.json + summary.md generation, completion output.
+Dispatches 16 agents directly (flat, parallel).
+Per-domain synthesis compiled from `prompts/shared/synthesis.md` + domain `_base.md` additions.
+Produces 4 domain reports + `summary.md`.
 
-### Phase 4: Polish (2 issues, 1 PR)
+### Phase 4: Close-out (1 issue, 1 PR)
 
-| Issue | Title | Deliverables |
-|-------|-------|-------------|
-| #12 | Update documentation for v1.0 | README with install instructions, CLAUDE.md with new structure, CHANGELOG |
-| #13 | Calibration pass against test codebase | Run all domains, verify output consistency, tune prompts |
+| Title | Branch | Deliverables |
+|-------|--------|-------------|
+| Close milestone: Code Review Plugin v1.0 | `chore/close-code-review-v1` | Update specs with new patterns, capture decision rationale, reconcile divergences, update docs (README, CLAUDE.md), update spec index, delete plan directory, close GitHub Milestone |
 
 ## Implementation Sequence
 
 ```
-Phase 0:  #1 Scaffolding
+Phase 0:  Scaffolding
               │
-Phase 1:  #2 Shared prompts
+Phase 1:  Shared prompts
               │
-Phase 2:  #3→#4 SRE (reference impl)
+Phase 2:  SRE domain (reference implementation)
               │
-          #5→#6 Security  ┐
-          #7→#8 Architecture  ├── Can parallel after SRE establishes the pattern
-          #9→#10 Data     ┘
+          Security domain    ┐
+          Architecture domain ├── Follow the SRE pattern; can parallel after SRE
+          Data domain        ┘
               │
-Phase 3:  #11 code-review:all (requires all 4 domain skills)
+Phase 3:  code-review:all (requires all 4 domain skills)
               │
-Phase 4:  #12 Docs  +  #13 Calibration
+Phase 4:  Close milestone
 ```
 
-**PR grouping** (8 PRs total):
-1. `chore/marketplace-scaffolding` — Issue #1
-2. `feat/shared-prompts` — Issue #2
-3. `feat/sre-domain` — Issues #3-#4
-4. `feat/security-domain` — Issues #5-#6
-5. `feat/architecture-domain` — Issues #7-#8
-6. `feat/data-domain` — Issues #9-#10
-7. `feat/code-review-all` — Issue #11
-8. `chore/v1-polish` — Issues #12-#13
+**8 issues, 8 PRs, 8 branches:**
+
+1. `chore/marketplace-scaffolding` — Scaffolding
+2. `feat/shared-prompts` — Shared prompts
+3. `feat/sre-domain` — SRE domain
+4. `feat/security-domain` — Security domain
+5. `feat/architecture-domain` — Architecture domain
+6. `feat/data-domain` — Data domain
+7. `feat/code-review-all` — code-review:all
+8. `chore/close-code-review-v1` — Close milestone
 
 ## Key Implementation Details
 
 ### Skill orchestrator pattern (each domain SKILL.md)
+
 1. **Scope detection**: path arg → use directly; PR number → `gh pr diff`; empty → `git diff` or interactive prompt; "." → `git diff main...HEAD`
 2. **Batch naming**: git tag > branch-shorthash > date-shorthash
 3. **Output dir**: `mkdir -p .code-review/<batch-name>/`
 4. **Dispatch**: spawn 4 domain agents in parallel via Task tool, passing scope
-5. **Synthesis**: collect → deduplicate (same file:line → merge, highest severity, most restrictive maturity) → aggregate maturity → prioritize (HYG > HIGH > MED > LOW)
+5. **Synthesis** (compiled from `prompts/shared/synthesis.md` + domain `_base.md`): collect → apply domain pre-filters (if any) → deduplicate (same file:line → merge, highest severity, most restrictive maturity) → aggregate maturity → prioritise (HYG > HIGH > MED > LOW)
 6. **Write**: output to `.code-review/<batch-name>/{domain}.md`
 7. **Report**: summary to user with finding counts and file path
 
-### Agent template pattern (each agent .md file)
+### Agent template pattern (generated by `compile.sh`)
+
 ```markdown
 ---
 name: {domain}-{pillar}
-description: {one-line description}. Spawned by /code-review:{domain}.
-model: sonnet
+description: {One-line description}. Spawned by /code-review:{domain} or /code-review:all.
+model: {sonnet or haiku — see Agent configuration section}
+tools: Read, Grep, Glob
 ---
 
 {Inlined shared content: maturity model, severity, design principles, output format, constraints}
@@ -233,6 +355,7 @@ model: sonnet
 {Inlined pillar prompt: focus areas, anti-patterns with code examples, checklist}
 
 ## Review Instructions
+
 1. Examine code in scope
 2. Apply {attack lens} to identify issues
 3. Apply {defence lens} to verify protections
@@ -242,23 +365,25 @@ model: sonnet
 ```
 
 ### Prompt size targets (to stay within agent context budgets)
-- Shared content: ~150 lines total across 5 files
-- Domain `_base.md`: ~200-250 lines each
-- Pillar prompts: ~80-120 lines each
-- **Total inlined per agent: ~430-520 lines (~3-4K tokens)** — well within limits
+
+- Shared content: ~180 lines total across 6 files
+- Domain `_base.md`: ~200–250 lines each
+- Pillar prompts: ~80–120 lines each
+- **Total inlined per agent: ~460–550 lines (~3–4K tokens)** — well within limits
 
 ## Risks
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| code-review:all nesting depth (skill → 4 skills → 4 agents each) | May hit Claude Code limits | Test early in Phase 3; fallback: all.md dispatches 16 agents directly |
-| Agent model selection (haiku for some agents) | Quality may be insufficient | Start with spec recommendations; upgrade to sonnet during calibration if needed |
-| Prompt distillation quality | Missing critical patterns from specs | SRE as reference impl; cross-check against previous repo; calibration pass |
+| Agent model selection (haiku for some agents) | Quality may be insufficient | Start with spec recommendations; upgrade to sonnet if quality is lacking |
+| Prompt distillation quality | Missing critical patterns from specs | SRE as reference implementation; cross-check against spike repo |
 | Batch name collisions | Overwrites previous reports | Append `-2`, `-3` if directory exists |
+| Plugin caching affects path resolution | Agents can not read prompts/ at runtime | This is by design — agents inline all content via compile.sh. No runtime file reads. |
+| 16 parallel agents in code-review:all | May hit Claude Code concurrency limits | Monitor during Phase 3; can batch into 4 waves of 4 if needed |
+| Prompt/agent drift | Agent files diverge from prompt sources after hand-edits | Prevented by compile.sh + pre-commit hook. Agents are never hand-edited. |
 
 ## Verification
 
-1. **Phase 0**: `claude plugin validate ./plugins/code-review` passes; `claude --plugin-dir ./plugins/code-review` loads; `/help` shows plugin
-2. **Phase 2 (per domain)**: `/code-review:sre ./path/to/test/file` produces a valid report at `.code-review/<batch>/sre.md` with all required sections
-3. **Phase 3**: `/code-review:all ./path/to/test/code` produces 4 sub-reports + summary.json + summary.md
-4. **Phase 4**: Run against a real codebase; verify output format consistency across all domains; verify deduplication in code-review:all
+1. **Phase 0**: `claude plugin validate ./plugins/code-review` passes; `claude --plugin-dir ./plugins/code-review` loads; `scripts/compile.sh` runs without error; pre-commit hook rejects a commit with a stale agent file
+2. **Phase 2 (per domain)**: `scripts/compile.sh` generates agents and skill from prompts; `/code-review:sre ./path/to/test/file` produces a valid report at `.code-review/<batch>/sre.md` with all required sections
+3. **Phase 3**: `/code-review:all ./path/to/test/code` produces 4 domain reports + `summary.md` in `.code-review/<batch>/`

--- a/plan/code-review-v1/BRIEF.md
+++ b/plan/code-review-v1/BRIEF.md
@@ -1,0 +1,90 @@
+# Code Review Plugin v1.0 — Planning Brief
+
+## Purpose
+
+Deliver the first plugin for the `donkey-developer/claude-plugins` marketplace: a code review plugin that extends generalist engineers' review capability across Architecture, Security, SRE, and Data Engineering.
+
+## What This Delivers
+
+- 5 slash commands: `/code-review:sre`, `/code-review:security`, `/code-review:architecture`, `/code-review:data`, `/code-review:all`
+- 16 domain-specific subagents (4 domains x 4 pillars)
+- A compilation pipeline that generates agents and skills from human-editable prompts
+- Output reports written to `.code-review/<batch-name>/`
+
+## Key Architecture Decisions
+
+### 1. Three-tier file structure
+
+```text
+plugins/code-review/
+├── skills/{domain}/SKILL.md      ← Orchestrators (user-triggered, dispatch + synthesise)
+├── agents/{domain}-{pillar}.md   ← Self-contained subagents (16 total, inlined prompts)
+└── prompts/                      ← Source of truth (human-editable, NOT read at runtime)
+    ├── shared/                   ← Cross-domain content (including synthesis rules)
+    └── {domain}/                 ← Domain + pillar content
+```
+
+### 2. Composition model
+
+- **Agents are self-contained.** Each agent file inlines all context it needs (shared + domain base + pillar).
+  Agents do NOT read external files at runtime.
+- **Prompts are the source of truth.** The `prompts/` directory is human-editable source.
+  Agent and skill files are "compiled" from prompts by `scripts/compile.sh`.
+- **Skills compile synthesis rules from the same sources.** Both standalone domain reviews and `/code-review:all` produce identical domain reports.
+- **Compilation is automated.** A pre-commit hook validates that generated files are in sync with their prompt sources.
+
+### 3. code-review:all dispatches 16 agents flat
+
+Subagents cannot spawn other subagents (Claude Code platform constraint).
+Flat dispatch spawns all 16 agents in parallel, each in its own context window.
+Only summarised results return to the parent, keeping context manageable.
+
+### 4. Agent model allocation
+
+| Domain | Pillar | Model | Rationale |
+|--------|--------|-------|-----------|
+| SRE | Response, Observability, Availability | sonnet | Nuanced judgement on production readiness |
+| SRE | Delivery | haiku | Binary checklist (backward-compatible or not) |
+| Security | AuthN/AuthZ, Data Protection, Input Validation | sonnet | Subtle exploit pattern recognition |
+| Security | Audit & Resilience | haiku | Binary checklist (audit logs present or not) |
+| Architecture | All 4 (Code, Service, System, Landscape) | sonnet | All levels require nuanced design judgement |
+| Data | All 4 (Architecture, Engineering, Quality, Governance) | sonnet | Contextual assessment of data fitness |
+
+### 5. Domain-specific synthesis rules
+
+- **Security:** Confidence filter — remove findings below 50% before deduplication.
+  Exploit path required for every finding.
+- **Data:** Scope filter — focus on SQL, dbt, Spark, pipeline configs.
+  Consumer-first perspective.
+- **SRE, Architecture:** No domain-specific synthesis beyond shared algorithm.
+
+### 6. Prompt size targets
+
+- Shared content: ~180 lines total across 6 files
+- Domain `_base.md`: ~200-250 lines each
+- Pillar prompts: ~80-120 lines each
+- **Total inlined per agent: ~460-550 lines (~3-4K tokens)** — well within context limits
+
+## Issue Sequence
+
+1. `01-scaffolding.tasks.md` → #18 "Create marketplace and plugin scaffolding" (no dependencies)
+2. `02-shared-prompts.tasks.md` → #19 "Create shared cross-domain prompts" (depends on #18)
+3. `03-sre-domain.tasks.md` → #20 "Create SRE domain review" (depends on #19, reference implementation)
+4. `04-security-domain.tasks.md` → #21 "Create Security domain review" (depends on #19, parallel after SRE)
+   `05-architecture-domain.tasks.md` → #22 "Create Architecture domain review" (depends on #19, parallel)
+   `06-data-domain.tasks.md` → #23 "Create Data domain review" (depends on #19, parallel)
+5. `07-code-review-all.tasks.md` → #24 "Create code-review:all orchestrator" (depends on #20-#23)
+6. `08-close.tasks.md` → #25 "Close milestone: Code Review Plugin v1.0" (depends on all above)
+
+## Sources
+
+- **Implementation plan:** `Planner.md` — full plan (advisory; specs in `spec/` are authoritative)
+- **Spike repo:** `https://github.com/LeeCampbell/code-review-llm` — cross-reference for tone and structure (advisory only; do not fetch at runtime)
+- **Review framework:** `spec/review-standards/review-framework.md`
+- **Design principles:** `spec/review-standards/design-principles.md`
+- **Orchestration:** `spec/review-standards/orchestration.md`
+- **Glossary:** `spec/review-standards/glossary.md`
+- **SRE specs:** `spec/domains/sre/spec.md` (index to all SRE spec files)
+- **Security specs:** `spec/domains/security/spec.md` (index to all Security spec files)
+- **Architecture specs:** `spec/domains/architecture/spec.md` (index to all Architecture spec files)
+- **Data specs:** `spec/domains/data/spec.md` (index to all Data spec files)

--- a/plan/code-review-v1/tasks/01-scaffolding.tasks.md
+++ b/plan/code-review-v1/tasks/01-scaffolding.tasks.md
@@ -1,0 +1,80 @@
+# Create marketplace and plugin scaffolding
+
+**Issue:** #18
+**Branch:** chore/marketplace-scaffolding
+**Depends on:** none
+**Brief ref:** BRIEF.md Sections 1-2
+
+## Tasks
+
+- [ ] **TASK-01: Create marketplace catalogue**
+  - **Goal:** Create the marketplace directory and catalogue file that registers available plugins
+  - **Brief ref:** BRIEF.md Section 1 (three-tier file structure)
+  - **Files:**
+    - Create `.claude-plugin/marketplace.json`
+  - **Spec ref:** `Planner.md` — Plugin model section
+  - **Verification:** File exists with valid JSON containing `code-review` plugin entry
+
+- [ ] **TASK-02: Create plugin manifest and directory structure**
+  - **Goal:** Create the plugin root, manifest, and all subdirectories
+  - **Brief ref:** BRIEF.md Section 1 (three-tier file structure)
+  - **Files:**
+    - Create `plugins/code-review/.claude-plugin/plugin.json`
+    - Create directories: `plugins/code-review/skills/`, `plugins/code-review/agents/`, `plugins/code-review/prompts/shared/`, `plugins/code-review/prompts/sre/`, `plugins/code-review/prompts/security/`, `plugins/code-review/prompts/architecture/`, `plugins/code-review/prompts/data/`, `plugins/code-review/scripts/`
+    - Create directories: `plugins/code-review/skills/all/`, `plugins/code-review/skills/sre/`, `plugins/code-review/skills/security/`, `plugins/code-review/skills/architecture/`, `plugins/code-review/skills/data/`
+  - **Verification:** `plugin.json` exists with valid JSON; all directories exist
+
+- [ ] **TASK-03: Create compile.conf**
+  - **Goal:** Create the agent metadata configuration file that maps each agent to its model and description
+  - **Brief ref:** BRIEF.md Section 4 (agent model allocation)
+  - **Files:**
+    - Create `plugins/code-review/prompts/compile.conf`
+  - **Spec ref:** `Planner.md` — Compilation pipeline section, Agent configuration section
+  - **Details:** 16 agent entries, each with: name, model (sonnet/haiku per BRIEF.md Section 4), one-line description. Also 5 skill entries for domain orchestrators.
+  - **Verification:** File contains 16 agent entries and 5 skill entries with correct model assignments
+
+- [ ] **TASK-04: Create compile.sh**
+  - **Goal:** Create the build script that generates agent and skill files from prompt sources
+  - **Brief ref:** BRIEF.md Section 2 (composition model)
+  - **Files:**
+    - Create `plugins/code-review/scripts/compile.sh`
+  - **Spec ref:** `Planner.md` — Compilation pipeline section
+  - **Details:**
+    - Reads `compile.conf` for agent metadata
+    - For each agent: concatenates shared prompts + domain `_base.md` + pillar prompt + review instructions → writes `agents/{domain}-{pillar}.md` with YAML frontmatter
+    - For each domain skill: concatenates skill template + `synthesis.md` + domain synthesis additions → writes `skills/{domain}/SKILL.md`
+    - For all skill: concatenates skill template + `synthesis.md` + all domain synthesis additions → writes `skills/all/SKILL.md`
+    - Supports `--check` mode that compares output to existing files and exits non-zero if out of sync
+    - Must be idempotent — running twice produces identical output
+  - **Verification:** Script runs without error (exits 0); `--check` mode works; script is executable
+
+- [ ] **TASK-05: Create pre-commit hook**
+  - **Goal:** Create a git pre-commit hook that validates compiled files are in sync with prompts
+  - **Brief ref:** BRIEF.md Section 2 (composition model)
+  - **Files:**
+    - Create `.githooks/pre-commit` (or configure in existing hooks directory)
+  - **Details:** Runs `scripts/compile.sh --check` and fails the commit with a message to run `scripts/compile.sh` if files are out of sync
+  - **Verification:** Hook is executable; `git config core.hooksPath` points to hooks directory
+
+- [ ] **TASK-06: Update .gitignore**
+  - **Goal:** Ensure `.code-review/` output directories are ignored by git
+  - **Files:**
+    - Edit `.gitignore` (create if needed)
+  - **Verification:** `.code-review/` is listed in `.gitignore`
+
+- [ ] **TASK-07: Update root README.md**
+  - **Goal:** Update the repository README to describe the marketplace and code-review plugin
+  - **Files:**
+    - Edit `README.md`
+  - **Verification:** README describes the marketplace concept and the code-review plugin
+
+- [ ] **TASK-08: Final verification**
+  - **Goal:** Verify all scaffolding deliverables are in place
+  - **Verification:**
+    - `.claude-plugin/marketplace.json` exists and is valid JSON
+    - `plugins/code-review/.claude-plugin/plugin.json` exists and is valid JSON
+    - `plugins/code-review/prompts/compile.conf` has 16 agent entries and 5 skill entries
+    - `plugins/code-review/scripts/compile.sh` is executable and runs without error
+    - Pre-commit hook is installed and executable
+    - `.gitignore` includes `.code-review/`
+    - Directory structure matches BRIEF.md Section 1

--- a/plan/code-review-v1/tasks/02-shared-prompts.tasks.md
+++ b/plan/code-review-v1/tasks/02-shared-prompts.tasks.md
@@ -1,0 +1,65 @@
+# Create shared cross-domain prompts
+
+**Issue:** #19
+**Branch:** feat/shared-prompts
+**Depends on:** #18
+**Brief ref:** BRIEF.md Sections 2, 5, 6
+
+## Tasks
+
+- [ ] **TASK-01: Create maturity-model.md**
+  - **Goal:** Distil the maturity model (Hygiene gate, L1/L2/L3, status indicators) into a concise prompt fragment
+  - **Brief ref:** BRIEF.md Section 6 (prompt size targets — shared content ~180 lines total)
+  - **Files:**
+    - Create `plugins/code-review/prompts/shared/maturity-model.md`
+  - **Spec ref:** `spec/review-standards/review-framework.md` — Maturity model section
+  - **Details:** Include Hygiene gate rules (irreversible, total, regulated), level descriptions (L1/L2/L3), status indicators (pass/partial/fail/locked), promotion rules. Keep concise — this is inlined into every agent.
+  - **Verification:** File exists; covers Hygiene gate, L1-L3 levels, status indicators; under 40 lines
+
+- [ ] **TASK-02: Create severity-framework.md**
+  - **Goal:** Distil the severity framework (HIGH/MEDIUM/LOW definitions) into a concise prompt fragment
+  - **Files:**
+    - Create `plugins/code-review/prompts/shared/severity-framework.md`
+  - **Spec ref:** `spec/review-standards/review-framework.md` — Severity section
+  - **Details:** HIGH (must fix before merge), MEDIUM (follow-up ticket), LOW (nice to have). Note that each domain contextualises severity around its own impact framing.
+  - **Verification:** File exists; defines 3 severity levels with merge-decision guidance; under 25 lines
+
+- [ ] **TASK-03: Create design-principles.md**
+  - **Goal:** Distil the 5 core design principles into a concise prompt fragment
+  - **Files:**
+    - Create `plugins/code-review/prompts/shared/design-principles.md`
+  - **Spec ref:** `spec/review-standards/design-principles.md`
+  - **Details:** Outcomes over techniques, questions over imperatives, positive observations, consequence-based hygiene, and the fifth principle. Keep actionable — agents must apply these, not just know them.
+  - **Verification:** File exists; captures all 5 principles; under 40 lines
+
+- [ ] **TASK-04: Create output-format.md**
+  - **Goal:** Define the standard output format for agent findings
+  - **Files:**
+    - Create `plugins/code-review/prompts/shared/output-format.md`
+  - **Spec ref:** `spec/review-standards/review-framework.md` — Output format section
+  - **Details:** Finding table columns, maturity table format, required sections (Summary, Findings, What's Good, Maturity Assessment). Include example templates.
+  - **Verification:** File exists; defines finding table and maturity table formats; includes section headings; under 40 lines
+
+- [ ] **TASK-05: Create constraints.md**
+  - **Goal:** Define the hard constraints that apply to all agents
+  - **Files:**
+    - Create `plugins/code-review/prompts/shared/constraints.md`
+  - **Spec ref:** `spec/review-standards/review-framework.md` — Constraints section
+  - **Details:** Read-only (no auto-fix), no cross-domain findings, no numeric scores, no tool prescriptions. These are non-negotiable rules every agent must follow.
+  - **Verification:** File exists; lists all constraints; under 20 lines
+
+- [ ] **TASK-06: Create synthesis.md**
+  - **Goal:** Define the synthesis algorithm used by skill orchestrators to combine pillar results
+  - **Files:**
+    - Create `plugins/code-review/prompts/shared/synthesis.md`
+  - **Spec ref:** `spec/review-standards/orchestration.md` — Synthesis section
+  - **Details:** Collect → deduplicate (same file:line → merge, highest severity, most restrictive maturity) → aggregate maturity → prioritise (HYG > HIGH > MED > LOW). Note placeholders for domain-specific pre-filters (Security confidence filter, Data scope filter). This file is inlined into every skill.
+  - **Verification:** File exists; defines complete synthesis algorithm with dedup, aggregation, prioritisation; under 40 lines
+
+- [ ] **TASK-07: Final verification**
+  - **Goal:** Verify all 6 shared prompt files exist with appropriate content and size
+  - **Verification:**
+    - All 6 files exist in `plugins/code-review/prompts/shared/`
+    - Total shared content is approximately 180 lines (within ±30 lines)
+    - Each file is self-contained and reusable across all 4 domains
+    - Run `scripts/compile.sh` — should execute without error (no agents to generate yet, but validates script finds shared prompts)

--- a/plan/code-review-v1/tasks/03-sre-domain.tasks.md
+++ b/plan/code-review-v1/tasks/03-sre-domain.tasks.md
@@ -1,0 +1,104 @@
+# Create SRE domain review
+
+**Issue:** #20
+**Branch:** feat/sre-domain
+**Depends on:** #19
+**Brief ref:** BRIEF.md Sections 1-6
+
+This is the **reference implementation** — the first domain built, establishing the pattern for Security, Architecture, and Data.
+
+## Sources
+
+- `spec/domains/sre/spec.md` — SRE specification index
+- `spec/domains/sre/anti-patterns.md` — anti-patterns with code examples
+- `spec/domains/sre/maturity-criteria.md` — SRE-specific maturity criteria
+- `spec/domains/sre/framework-map.md` — ROAD framework mapping
+- `spec/domains/sre/glossary.md` — SRE-specific terms
+- `spec/domains/sre/calibration.md` — calibration guidance
+- Spike cross-reference (advisory): `https://github.com/LeeCampbell/code-review-llm` → `.claude/prompts/sre/`
+
+## Tasks
+
+- [ ] **TASK-01: Create SRE _base.md**
+  - **Goal:** Distil the SRE domain foundation into a base prompt covering ROAD framework, SEEMS/FaCTOR duality, maturity criteria, and glossary
+  - **Brief ref:** BRIEF.md Section 6 (domain `_base.md`: ~200-250 lines)
+  - **Files:**
+    - Create `plugins/code-review/prompts/sre/_base.md`
+  - **Spec ref:** `spec/domains/sre/spec.md`, `spec/domains/sre/framework-map.md`, `spec/domains/sre/maturity-criteria.md`, `spec/domains/sre/glossary.md`
+  - **Details:**
+    - Purpose statement (what SRE review evaluates)
+    - ROAD framework overview (Response, Observability, Availability, Delivery)
+    - SEEMS/FaCTOR duality (attack/defence lenses)
+    - Domain-specific maturity criteria for each level (Hygiene, L1, L2, L3)
+    - SRE glossary (key terms the agent needs)
+    - `## Review Instructions` section with SEEMS/FaCTOR lens names
+    - No domain-specific synthesis rules for SRE (note this explicitly)
+  - **Verification:** File exists; ~200-250 lines; covers ROAD, SEEMS/FaCTOR, maturity criteria, glossary; has Review Instructions section
+
+- [ ] **TASK-02: Create SRE response.md pillar prompt**
+  - **Goal:** Create the Response pillar prompt with focus areas, anti-patterns (RP-01..RP-06), and checklist
+  - **Brief ref:** BRIEF.md Section 6 (pillar prompts: ~80-120 lines)
+  - **Files:**
+    - Create `plugins/code-review/prompts/sre/response.md`
+  - **Spec ref:** `spec/domains/sre/anti-patterns.md` (RP-01 through RP-06), `spec/domains/sre/calibration.md`
+  - **Details:** Pillar scope, anti-pattern catalogue with concise code examples, review checklist. Severity is about production consequence (error propagation, missing runbooks, unsafe retries).
+  - **Verification:** File exists; ~80-120 lines; includes all RP anti-patterns; has checklist
+
+- [ ] **TASK-03: Create SRE observability.md pillar prompt**
+  - **Goal:** Create the Observability pillar prompt with focus areas, anti-patterns (OP-01..OP-07), and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/sre/observability.md`
+  - **Spec ref:** `spec/domains/sre/anti-patterns.md` (OP-01 through OP-07), `spec/domains/sre/calibration.md`
+  - **Verification:** File exists; ~80-120 lines; includes all OP anti-patterns; has checklist
+
+- [ ] **TASK-04: Create SRE availability.md pillar prompt**
+  - **Goal:** Create the Availability pillar prompt with focus areas, anti-patterns (AP-01..AP-10), and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/sre/availability.md`
+  - **Spec ref:** `spec/domains/sre/anti-patterns.md` (AP-01 through AP-10), `spec/domains/sre/calibration.md`
+  - **Verification:** File exists; ~80-120 lines; includes all AP anti-patterns; has checklist
+
+- [ ] **TASK-05: Create SRE delivery.md pillar prompt**
+  - **Goal:** Create the Delivery pillar prompt with focus areas, anti-patterns (DP-01..DP-09), and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/sre/delivery.md`
+  - **Spec ref:** `spec/domains/sre/anti-patterns.md` (DP-01 through DP-09), `spec/domains/sre/calibration.md`
+  - **Verification:** File exists; ~80-120 lines; includes all DP anti-patterns; has checklist
+
+- [ ] **TASK-06: Add SRE entries to compile.conf**
+  - **Goal:** Add the 4 SRE agent entries and 1 SRE skill entry to compile.conf
+  - **Files:**
+    - Edit `plugins/code-review/prompts/compile.conf`
+  - **Details:**
+    - `sre-response`: model=sonnet, description references Response pillar
+    - `sre-observability`: model=sonnet, description references Observability pillar
+    - `sre-availability`: model=sonnet, description references Availability pillar
+    - `sre-delivery`: model=haiku, description references Delivery pillar
+    - `sre` skill: description references SRE domain review
+  - **Verification:** compile.conf has 4 SRE agent entries with correct models and 1 SRE skill entry
+
+- [ ] **TASK-07: Run compile.sh and verify generated files**
+  - **Goal:** Generate the 4 SRE agent files and the SRE skill file from prompts
+  - **Files generated:**
+    - `plugins/code-review/agents/sre-response.md`
+    - `plugins/code-review/agents/sre-observability.md`
+    - `plugins/code-review/agents/sre-availability.md`
+    - `plugins/code-review/agents/sre-delivery.md`
+    - `plugins/code-review/skills/sre/SKILL.md`
+  - **Verification:**
+    - `scripts/compile.sh` exits 0
+    - All 5 files exist
+    - Each agent file has correct YAML frontmatter (name, description, model, tools)
+    - Each agent file contains inlined shared + domain + pillar content
+    - Skill file contains synthesis rules compiled from `synthesis.md`
+    - `scripts/compile.sh --check` exits 0 (files are in sync)
+
+- [ ] **TASK-08: Final verification**
+  - **Goal:** Verify the complete SRE domain is correctly built and sets the reference pattern
+  - **Verification:**
+    - 5 prompt source files exist in `prompts/sre/`
+    - 4 agent files exist in `agents/` with correct frontmatter and content
+    - 1 skill file exists in `skills/sre/SKILL.md` with orchestrator logic and synthesis rules
+    - Agent files are self-contained (grep for no `Read` of prompt files)
+    - Total agent file sizes are within prompt size targets (~460-550 lines each)
+    - `compile.sh --check` confirms sync

--- a/plan/code-review-v1/tasks/04-security-domain.tasks.md
+++ b/plan/code-review-v1/tasks/04-security-domain.tasks.md
@@ -1,0 +1,116 @@
+# Create Security domain review
+
+**Issue:** #21
+**Branch:** feat/security-domain
+**Depends on:** #19
+**Brief ref:** BRIEF.md Sections 1-6
+
+Follows the pattern established by the SRE reference implementation.
+
+## Sources
+
+- `spec/domains/security/spec.md` — Security specification index
+- `spec/domains/security/anti-patterns.md` — anti-patterns with code examples
+- `spec/domains/security/maturity-criteria.md` — Security-specific maturity criteria
+- `spec/domains/security/framework-map.md` — STRIDE framework mapping
+- `spec/domains/security/glossary.md` — Security-specific terms
+- `spec/domains/security/calibration.md` — calibration guidance
+- Spike cross-reference (advisory): `https://github.com/LeeCampbell/code-review-llm` → `.claude/prompts/security/`
+
+## Domain-specific notes
+
+- **STRIDE framework**, threat/property duality
+- **Confidence thresholds:** Remove findings below 50% confidence before deduplication (HIGH >80%, MEDIUM 50-80%, LOW <50% → do not report)
+- **Exploit path required** for every finding — vulnerability without exploit path is theoretical, not a finding
+- **Explicit exclusion list:** No dependency scanning, no secret scanning from git history, no penetration testing
+- **Tampering boundary rule:** Must be within code boundary, not infrastructure
+
+## Tasks
+
+- [ ] **TASK-01: Create Security _base.md**
+  - **Goal:** Distil the Security domain foundation into a base prompt covering STRIDE framework, threat/property duality, confidence thresholds, and glossary
+  - **Brief ref:** BRIEF.md Section 6 (domain `_base.md`: ~200-250 lines)
+  - **Files:**
+    - Create `plugins/code-review/prompts/security/_base.md`
+  - **Spec ref:** `spec/domains/security/spec.md`, `spec/domains/security/framework-map.md`, `spec/domains/security/maturity-criteria.md`, `spec/domains/security/glossary.md`
+  - **Details:**
+    - Purpose statement (what Security review evaluates)
+    - STRIDE overview (6 threat categories distributed across 4 pillars)
+    - Threat/Property duality (STRIDE Threats attack lens / Security Properties defence lens)
+    - Confidence thresholds (HIGH >80%, MEDIUM 50-80%, LOW <50%)
+    - Exclusion list (dependency scanning, secret scanning, penetration testing)
+    - Domain-specific maturity criteria
+    - Security glossary
+    - `## Review Instructions` section with STRIDE Threats/Security Properties lens names
+    - `## Synthesis Pre-filter` section: confidence filter (remove <50% before dedup)
+  - **Verification:** File exists; ~200-250 lines; covers STRIDE, confidence thresholds, exclusion list; has synthesis pre-filter section
+
+- [ ] **TASK-02: Create Security authn-authz.md pillar prompt**
+  - **Goal:** Create the Authentication & Authorisation pillar prompt with focus areas, anti-patterns, and checklist
+  - **Brief ref:** BRIEF.md Section 6 (pillar prompts: ~80-120 lines)
+  - **Files:**
+    - Create `plugins/code-review/prompts/security/authn-authz.md`
+  - **Spec ref:** `spec/domains/security/anti-patterns.md` (AuthN/AuthZ patterns), `spec/domains/security/calibration.md`
+  - **Details:** STRIDE categories: Spoofing, Elevation of Privilege. Covers authentication bypass patterns, privilege escalation, session management, token handling. Each finding must include exploit scenario.
+  - **Verification:** File exists; ~80-120 lines; includes anti-patterns with exploit scenarios; has checklist
+
+- [ ] **TASK-03: Create Security data-protection.md pillar prompt**
+  - **Goal:** Create the Data Protection pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/security/data-protection.md`
+  - **Spec ref:** `spec/domains/security/anti-patterns.md` (Data Protection patterns), `spec/domains/security/calibration.md`
+  - **Details:** STRIDE categories: Information Disclosure, Tampering. Covers crypto usage, secrets exposure, data classification, at-rest/in-transit encryption. Tampering must be within code boundary.
+  - **Verification:** File exists; ~80-120 lines; includes anti-patterns with exploit scenarios; has checklist
+
+- [ ] **TASK-04: Create Security input-validation.md pillar prompt**
+  - **Goal:** Create the Input Validation pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/security/input-validation.md`
+  - **Spec ref:** `spec/domains/security/anti-patterns.md` (Input Validation patterns), `spec/domains/security/calibration.md`
+  - **Details:** STRIDE categories: Tampering, Denial of Service. Covers injection patterns (SQL, XSS, command), deserialisation, file upload, regex DoS. Framework-aware — note when frameworks handle validation.
+  - **Verification:** File exists; ~80-120 lines; includes anti-patterns with exploit scenarios; has checklist
+
+- [ ] **TASK-05: Create Security audit-resilience.md pillar prompt**
+  - **Goal:** Create the Audit & Resilience pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/security/audit-resilience.md`
+  - **Spec ref:** `spec/domains/security/anti-patterns.md` (Audit & Resilience patterns), `spec/domains/security/calibration.md`
+  - **Details:** STRIDE categories: Repudiation, Denial of Service. Covers audit logging, rate limiting, circuit breakers, error handling (information leakage). Binary checklist nature (present/absent).
+  - **Verification:** File exists; ~80-120 lines; includes anti-patterns; has checklist
+
+- [ ] **TASK-06: Add Security entries to compile.conf**
+  - **Goal:** Add the 4 Security agent entries and 1 Security skill entry to compile.conf
+  - **Files:**
+    - Edit `plugins/code-review/prompts/compile.conf`
+  - **Details:**
+    - `security-authn-authz`: model=sonnet
+    - `security-data-protection`: model=sonnet
+    - `security-input-validation`: model=sonnet
+    - `security-audit-resilience`: model=haiku
+    - `security` skill entry
+  - **Verification:** compile.conf has 4 Security agent entries with correct models and 1 Security skill entry
+
+- [ ] **TASK-07: Run compile.sh and verify generated files**
+  - **Goal:** Generate the 4 Security agent files and the Security skill file from prompts
+  - **Files generated:**
+    - `plugins/code-review/agents/security-authn-authz.md`
+    - `plugins/code-review/agents/security-data-protection.md`
+    - `plugins/code-review/agents/security-input-validation.md`
+    - `plugins/code-review/agents/security-audit-resilience.md`
+    - `plugins/code-review/skills/security/SKILL.md`
+  - **Verification:**
+    - `scripts/compile.sh` exits 0
+    - All 5 files exist with correct frontmatter and inlined content
+    - Security skill includes confidence filter in synthesis rules
+    - `scripts/compile.sh --check` exits 0
+
+- [ ] **TASK-08: Final verification**
+  - **Goal:** Verify the complete Security domain is correctly built
+  - **Verification:**
+    - 5 prompt source files exist in `prompts/security/`
+    - 4 agent files exist in `agents/` with correct frontmatter
+    - 1 skill file exists in `skills/security/SKILL.md`
+    - Confidence filter present in skill synthesis rules
+    - Exclusion list present in agent prompts
+    - Exploit path requirement present in agent prompts
+    - `compile.sh --check` confirms sync

--- a/plan/code-review-v1/tasks/05-architecture-domain.tasks.md
+++ b/plan/code-review-v1/tasks/05-architecture-domain.tasks.md
@@ -1,0 +1,116 @@
+# Create Architecture domain review
+
+**Issue:** #22
+**Branch:** feat/architecture-domain
+**Depends on:** #19
+**Brief ref:** BRIEF.md Sections 1-6
+
+Follows the pattern established by the SRE reference implementation.
+
+## Sources
+
+- `spec/domains/architecture/spec.md` — Architecture specification index
+- `spec/domains/architecture/anti-patterns.md` — anti-patterns with code examples
+- `spec/domains/architecture/maturity-criteria.md` — Architecture-specific maturity criteria
+- `spec/domains/architecture/framework-map.md` — C4 framework mapping
+- `spec/domains/architecture/glossary.md` — Architecture-specific terms
+- `spec/domains/architecture/calibration.md` — calibration guidance
+- Spike cross-reference (advisory): `https://github.com/LeeCampbell/code-review-llm` → `.claude/prompts/architecture/`
+
+## Domain-specific notes
+
+- **C4 zoom levels** — Code, Service, System, Landscape at increasing scope
+- **Principles/Erosion duality** — Design Principles (what should this look like?) vs Erosion Patterns (how does this go wrong?)
+- **Adaptive to project size** — Landscape and System may return "no findings" on small projects; this is correct, not a gap
+- **Design-time focus** — Evaluates decisions, not just implementation ("is this the right pattern?" not "is it configured?")
+- **Do NOT prescribe patterns by name** — Describe structural properties, not "use DDD" or "use Clean Architecture"
+- **All 4 agents use sonnet** — all levels require nuanced design judgement
+
+## Tasks
+
+- [ ] **TASK-01: Create Architecture _base.md**
+  - **Goal:** Distil the Architecture domain foundation into a base prompt covering C4 zoom levels, principles/erosion duality, maturity criteria, and glossary
+  - **Brief ref:** BRIEF.md Section 6 (domain `_base.md`: ~200-250 lines)
+  - **Files:**
+    - Create `plugins/code-review/prompts/architecture/_base.md`
+  - **Spec ref:** `spec/domains/architecture/spec.md`, `spec/domains/architecture/framework-map.md`, `spec/domains/architecture/maturity-criteria.md`, `spec/domains/architecture/glossary.md`
+  - **Details:**
+    - Purpose statement (what Architecture review evaluates)
+    - C4 zoom levels overview (Code → Service → System → Landscape)
+    - Principles/Erosion duality (design principles attack lens / erosion patterns defence lens)
+    - Adaptive scaling — "no findings" is valid at higher zoom levels for smaller projects
+    - Design-time vs run-time distinction (Architecture owns design-time; SRE owns run-time)
+    - Domain-specific maturity criteria
+    - Architecture glossary
+    - `## Review Instructions` section with Design Principles/Erosion Patterns lens names
+    - No domain-specific synthesis rules for Architecture (note explicitly)
+  - **Verification:** File exists; ~200-250 lines; covers C4, duality, adaptive scaling; has Review Instructions
+
+- [ ] **TASK-02: Create Architecture code.md pillar prompt**
+  - **Goal:** Create the Code zoom-level pillar prompt with focus areas, anti-patterns, and checklist
+  - **Brief ref:** BRIEF.md Section 6 (pillar prompts: ~80-120 lines)
+  - **Files:**
+    - Create `plugins/code-review/prompts/architecture/code.md`
+  - **Spec ref:** `spec/domains/architecture/anti-patterns.md` (Code-level patterns), `spec/domains/architecture/calibration.md`
+  - **Details:** SOLID compliance (describe properties, not acronyms), coupling/cohesion, naming, testability. Describe structural properties, not pattern names.
+  - **Verification:** File exists; ~80-120 lines; does NOT prescribe patterns by name; has checklist
+
+- [ ] **TASK-03: Create Architecture service.md pillar prompt**
+  - **Goal:** Create the Service zoom-level pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/architecture/service.md`
+  - **Spec ref:** `spec/domains/architecture/anti-patterns.md` (Service-level patterns), `spec/domains/architecture/calibration.md`
+  - **Details:** Bounded context alignment, layering violations, deployability, API design, dependency direction.
+  - **Verification:** File exists; ~80-120 lines; has checklist
+
+- [ ] **TASK-04: Create Architecture system.md pillar prompt**
+  - **Goal:** Create the System zoom-level pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/architecture/system.md`
+  - **Spec ref:** `spec/domains/architecture/anti-patterns.md` (System-level patterns), `spec/domains/architecture/calibration.md`
+  - **Details:** Inter-service coupling, stability patterns, data flow, integration patterns. May return "no findings" for monoliths.
+  - **Verification:** File exists; ~80-120 lines; has checklist
+
+- [ ] **TASK-05: Create Architecture landscape.md pillar prompt**
+  - **Goal:** Create the Landscape zoom-level pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/architecture/landscape.md`
+  - **Spec ref:** `spec/domains/architecture/anti-patterns.md` (Landscape-level patterns), `spec/domains/architecture/calibration.md`
+  - **Details:** Governance, context maps, ADR traceability, technology radar alignment. Most likely to return "no findings" on smaller projects.
+  - **Verification:** File exists; ~80-120 lines; has checklist
+
+- [ ] **TASK-06: Add Architecture entries to compile.conf**
+  - **Goal:** Add the 4 Architecture agent entries and 1 Architecture skill entry to compile.conf
+  - **Files:**
+    - Edit `plugins/code-review/prompts/compile.conf`
+  - **Details:**
+    - `architecture-code`: model=sonnet
+    - `architecture-service`: model=sonnet
+    - `architecture-system`: model=sonnet
+    - `architecture-landscape`: model=sonnet
+    - `architecture` skill entry
+  - **Verification:** compile.conf has 4 Architecture agent entries (all sonnet) and 1 Architecture skill entry
+
+- [ ] **TASK-07: Run compile.sh and verify generated files**
+  - **Goal:** Generate the 4 Architecture agent files and the Architecture skill file from prompts
+  - **Files generated:**
+    - `plugins/code-review/agents/architecture-code.md`
+    - `plugins/code-review/agents/architecture-service.md`
+    - `plugins/code-review/agents/architecture-system.md`
+    - `plugins/code-review/agents/architecture-landscape.md`
+    - `plugins/code-review/skills/architecture/SKILL.md`
+  - **Verification:**
+    - `scripts/compile.sh` exits 0
+    - All 5 files exist with correct frontmatter (all sonnet)
+    - No pattern names prescribed in agent content
+    - `scripts/compile.sh --check` exits 0
+
+- [ ] **TASK-08: Final verification**
+  - **Goal:** Verify the complete Architecture domain is correctly built
+  - **Verification:**
+    - 5 prompt source files exist in `prompts/architecture/`
+    - 4 agent files exist in `agents/` with correct frontmatter (all sonnet)
+    - 1 skill file exists in `skills/architecture/SKILL.md`
+    - No pattern names prescribed (grep for "use DDD", "use Clean Architecture", etc.)
+    - Adaptive scaling noted in agent prompts
+    - `compile.sh --check` confirms sync

--- a/plan/code-review-v1/tasks/06-data-domain.tasks.md
+++ b/plan/code-review-v1/tasks/06-data-domain.tasks.md
@@ -1,0 +1,123 @@
+# Create Data domain review
+
+**Issue:** #23
+**Branch:** feat/data-domain
+**Depends on:** #19
+**Brief ref:** BRIEF.md Sections 1-6
+
+Follows the pattern established by the SRE reference implementation.
+
+## Sources
+
+- `spec/domains/data/spec.md` — Data specification index
+- `spec/domains/data/anti-patterns.md` — anti-patterns with code examples
+- `spec/domains/data/maturity-criteria.md` — Data-specific maturity criteria
+- `spec/domains/data/framework-map.md` — Four Pillars framework mapping
+- `spec/domains/data/glossary.md` — Data-specific terms
+- `spec/domains/data/calibration.md` — calibration guidance
+- Spike cross-reference (advisory): `https://github.com/LeeCampbell/code-review-llm` → `.claude/prompts/data/`
+
+## Domain-specific notes
+
+- **Four Pillars** — Architecture, Engineering, Quality, Governance
+- **Guiding mantra:** "Trusted and Timely"
+- **Quality Dimensions/Decay Patterns duality** — DAMA DMBOK dimensions (what makes data trustworthy?) vs Decay Patterns (how does data go wrong?)
+- **Consumer-first perspective** — evaluate from downstream consumer perspective, not producer
+- **Fail-safe defaults** — unexpected input should fail visibly, not silently drop/coerce
+- **Do NOT prescribe modelling approaches** — describe structural properties, not "use star schema" or "3NF"
+- **L2 has 5 criteria** (not 4 like other domains)
+- **Data-specific file scoping** — SQL, dbt, Spark, pipeline configs, schema files, migration scripts
+- **All 4 agents use sonnet** — contextual assessment of data fitness
+
+## Tasks
+
+- [ ] **TASK-01: Create Data _base.md**
+  - **Goal:** Distil the Data domain foundation into a base prompt covering Four Pillars, quality dimensions/decay patterns duality, maturity criteria, and glossary
+  - **Brief ref:** BRIEF.md Section 6 (domain `_base.md`: ~200-250 lines)
+  - **Files:**
+    - Create `plugins/code-review/prompts/data/_base.md`
+  - **Spec ref:** `spec/domains/data/spec.md`, `spec/domains/data/framework-map.md`, `spec/domains/data/maturity-criteria.md`, `spec/domains/data/glossary.md`
+  - **Details:**
+    - Purpose statement (what Data review evaluates)
+    - Four Pillars overview (Architecture, Engineering, Quality, Governance)
+    - "Trusted and Timely" mantra
+    - Quality Dimensions/Decay Patterns duality
+    - Consumer-first perspective principle
+    - Fail-safe defaults principle
+    - Domain-specific maturity criteria (note L2 has 5 criteria)
+    - Data glossary
+    - `## Review Instructions` section with Quality Dimensions/Decay Patterns lens names
+    - `## Synthesis Pre-filter` section: data-specific file scoping (SQL, dbt, Spark, pipeline configs)
+  - **Verification:** File exists; ~200-250 lines; covers Four Pillars, duality, consumer-first, fail-safe; has synthesis pre-filter
+
+- [ ] **TASK-02: Create Data architecture.md pillar prompt**
+  - **Goal:** Create the Data Architecture pillar prompt with focus areas, anti-patterns, and checklist
+  - **Brief ref:** BRIEF.md Section 6 (pillar prompts: ~80-120 lines)
+  - **Files:**
+    - Create `plugins/code-review/prompts/data/architecture.md`
+  - **Spec ref:** `spec/domains/data/anti-patterns.md` (Architecture patterns), `spec/domains/data/calibration.md`
+  - **Details:** Schema design, domain boundaries, contract completeness, data product boundaries. Describe structural properties, not modelling approaches.
+  - **Verification:** File exists; ~80-120 lines; does NOT prescribe modelling approaches; has checklist
+
+- [ ] **TASK-03: Create Data engineering.md pillar prompt**
+  - **Goal:** Create the Data Engineering pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/data/engineering.md`
+  - **Spec ref:** `spec/domains/data/anti-patterns.md` (Engineering patterns), `spec/domains/data/calibration.md`
+  - **Details:** Transformation correctness, idempotency, performance, pipeline reliability. Fail-safe defaults — silent data loss is a critical finding.
+  - **Verification:** File exists; ~80-120 lines; has checklist
+
+- [ ] **TASK-04: Create Data quality.md pillar prompt**
+  - **Goal:** Create the Data Quality pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/data/quality.md`
+  - **Spec ref:** `spec/domains/data/anti-patterns.md` (Quality patterns), `spec/domains/data/calibration.md`
+  - **Details:** Freshness SLOs, validation coverage, documentation adequacy, completeness, accuracy. Consumer-first — "how will consumers experience this data?"
+  - **Verification:** File exists; ~80-120 lines; has checklist
+
+- [ ] **TASK-05: Create Data governance.md pillar prompt**
+  - **Goal:** Create the Data Governance pillar prompt with focus areas, anti-patterns, and checklist
+  - **Files:**
+    - Create `plugins/code-review/prompts/data/governance.md`
+  - **Spec ref:** `spec/domains/data/anti-patterns.md` (Governance patterns), `spec/domains/data/calibration.md`
+  - **Details:** Compliance analysis, PII identification, lifecycle management, retention policies, access controls. Regulatory severity (GDPR, CCPA violations).
+  - **Verification:** File exists; ~80-120 lines; has checklist
+
+- [ ] **TASK-06: Add Data entries to compile.conf**
+  - **Goal:** Add the 4 Data agent entries and 1 Data skill entry to compile.conf
+  - **Files:**
+    - Edit `plugins/code-review/prompts/compile.conf`
+  - **Details:**
+    - `data-architecture`: model=sonnet
+    - `data-engineering`: model=sonnet
+    - `data-quality`: model=sonnet
+    - `data-governance`: model=sonnet
+    - `data` skill entry
+  - **Verification:** compile.conf has 4 Data agent entries (all sonnet) and 1 Data skill entry
+
+- [ ] **TASK-07: Run compile.sh and verify generated files**
+  - **Goal:** Generate the 4 Data agent files and the Data skill file from prompts
+  - **Files generated:**
+    - `plugins/code-review/agents/data-architecture.md`
+    - `plugins/code-review/agents/data-engineering.md`
+    - `plugins/code-review/agents/data-quality.md`
+    - `plugins/code-review/agents/data-governance.md`
+    - `plugins/code-review/skills/data/SKILL.md`
+  - **Verification:**
+    - `scripts/compile.sh` exits 0
+    - All 5 files exist with correct frontmatter (all sonnet)
+    - Data skill includes scope filter in synthesis rules
+    - Consumer-first perspective present in agent prompts
+    - No modelling approaches prescribed
+    - `scripts/compile.sh --check` exits 0
+
+- [ ] **TASK-08: Final verification**
+  - **Goal:** Verify the complete Data domain is correctly built
+  - **Verification:**
+    - 5 prompt source files exist in `prompts/data/`
+    - 4 agent files exist in `agents/` with correct frontmatter (all sonnet)
+    - 1 skill file exists in `skills/data/SKILL.md`
+    - Scope filter present in skill synthesis rules
+    - Consumer-first and fail-safe defaults in agent prompts
+    - No modelling approaches prescribed (grep for "star schema", "3NF", etc.)
+    - `compile.sh --check` confirms sync

--- a/plan/code-review-v1/tasks/07-code-review-all.tasks.md
+++ b/plan/code-review-v1/tasks/07-code-review-all.tasks.md
@@ -1,0 +1,59 @@
+# Create code-review:all orchestrator
+
+**Issue:** #24
+**Branch:** feat/code-review-all
+**Depends on:** #20, #21, #22, #23
+**Brief ref:** BRIEF.md Section 3 (flat dispatch)
+
+## Sources
+
+- `Planner.md` — code-review:all dispatch strategy section
+- `spec/review-standards/orchestration.md` — orchestration spec
+- `plugins/code-review/prompts/shared/synthesis.md` — shared synthesis rules
+- Each domain `_base.md` — domain-specific synthesis additions
+
+## Tasks
+
+- [ ] **TASK-01: Create all skill prompt source**
+  - **Goal:** Create or update the prompt source content that the compile script uses to generate `skills/all/SKILL.md`
+  - **Brief ref:** BRIEF.md Section 3 (flat dispatch of 16 agents)
+  - **Files:**
+    - Create/edit prompt source files as needed for the all-domain skill template
+  - **Details:**
+    - Scope detection (same algorithm as domain skills): path → use directly; PR# → `gh pr diff`; empty → `git diff` or prompt; "." → `git diff main...HEAD`
+    - Batch naming: git tag > branch-shorthash > date-shorthash
+    - Output dir: `mkdir -p .code-review/<batch-name>/`
+    - Dispatch: spawn all 16 agents in parallel via Task tool, passing scope
+    - Collect: gather results from all 16 agents
+    - Per-domain synthesis: group by domain (4 groups of 4), apply `synthesis.md` + domain pre-filters, write domain report
+    - Cross-domain summary: `.code-review/<batch-name>/summary.md`
+    - Report: summary to user with finding counts and file paths
+  - **Verification:** Prompt source exists with complete orchestration logic
+
+- [ ] **TASK-02: Run compile.sh to generate skills/all/SKILL.md**
+  - **Goal:** Generate the all-domain skill file from prompts
+  - **Files generated:**
+    - `plugins/code-review/skills/all/SKILL.md`
+  - **Verification:**
+    - `scripts/compile.sh` exits 0
+    - `skills/all/SKILL.md` exists
+    - Skill dispatches 16 agents (not 4 domain skills)
+    - Per-domain synthesis includes domain-specific pre-filters (Security confidence, Data scope)
+    - `scripts/compile.sh --check` exits 0
+
+- [ ] **TASK-03: Verify all 16 agents and 5 skills are complete**
+  - **Goal:** Full inventory check of all generated files
+  - **Verification:**
+    - 16 agent files exist in `agents/` with correct frontmatter
+    - 5 skill files exist in `skills/` (sre, security, architecture, data, all)
+    - All prompt source files exist (6 shared + 4 domains x 5 files = 26 total)
+    - `compile.sh --check` exits 0 for all files
+    - `plugin.json` correctly declares all 5 skills
+
+- [ ] **TASK-04: Final verification**
+  - **Goal:** Verify the complete code-review:all orchestrator works end-to-end
+  - **Verification:**
+    - `skills/all/SKILL.md` exists with flat dispatch of 16 agents
+    - Synthesis rules are identical to standalone domain skills (compiled from same sources)
+    - Output structure: `.code-review/<batch>/` with 4 domain reports + `summary.md`
+    - Batch name collision handling (append `-2`, `-3` if directory exists)

--- a/plan/code-review-v1/tasks/08-close.tasks.md
+++ b/plan/code-review-v1/tasks/08-close.tasks.md
@@ -1,0 +1,44 @@
+# Close milestone: Code Review Plugin v1.0
+
+**Issue:** #25
+**Branch:** chore/close-code-review-v1
+**Depends on:** #18, #19, #20, #21, #22, #23, #24
+**Brief ref:** BRIEF.md (entire document — read as source material before updating specs)
+
+## Tasks
+
+- [ ] **TASK-01: Update specs with new patterns**
+  - **Goal:** Add any implementation patterns introduced during this milestone to the relevant spec files under `spec/`
+  - **Details:** Review all PRs merged during this milestone. Identify patterns not yet captured in specs (e.g. compile pipeline pattern, three-tier file structure, flat dispatch strategy, prompt size targets).
+  - **Verification:** Each new pattern has a section in the appropriate spec file
+
+- [ ] **TASK-02: Capture decision rationale**
+  - **Goal:** Extract rationale from `BRIEF.md` and implementation experience — trade-offs considered, alternatives rejected, constraints that drove decisions — and add to the relevant spec files under `spec/`
+  - **Details:** Key decisions to capture: flat dispatch vs nested dispatch, haiku vs sonnet model selection, compilation vs runtime file reads, confidence filter threshold, prompt size budgets.
+  - **Verification:** Each significant decision from BRIEF.md has rationale captured in a spec file
+
+- [ ] **TASK-03: Reconcile spec divergences**
+  - **Goal:** Where implementation intentionally diverged from the planning brief, update the permanent specs under `spec/` to match reality
+  - **Details:** Compare BRIEF.md and Planner.md against what was actually built. Update specs to reflect reality, not intent.
+  - **Verification:** No contradictions between specs and implemented code
+
+- [ ] **TASK-04: Add new vocabulary**
+  - **Goal:** Add any terms coined during implementation to the relevant glossary files
+  - **Details:** Check for new terms in: compile.conf, compile.sh, skill orchestrators, agent frontmatter, synthesis rules.
+  - **Verification:** All new terms are defined in a glossary
+
+- [ ] **TASK-05: Update spec index**
+  - **Goal:** Ensure every `.md` file under `spec/` has an entry in `spec/README.md` with title and one-line description
+  - **Verification:** `spec/README.md` entries match the actual files in `spec/`
+
+- [ ] **TASK-06: Delete plan directory**
+  - **Goal:** Remove `plan/code-review-v1/` — plans are transient, specs are permanent. Plans remain in git history.
+  - **Verification:** `plan/code-review-v1/` does not exist
+
+- [ ] **TASK-07: Delete Planner.md**
+  - **Goal:** Remove `Planner.md` from the repo root — its content has been migrated to the BRIEF.md (now deleted) and permanent specs.
+  - **Verification:** `Planner.md` does not exist at repo root
+
+- [ ] **TASK-08: Close GitHub Milestone**
+  - **Goal:** Verify all issues are closed, all PRs merged, then close the Milestone
+  - **Verification:** GitHub Milestone shows as closed with 100% completion


### PR DESCRIPTION
## Summary

- Create milestone-level planning brief (`plan/code-review-v1/BRIEF.md`) and 8 task files (59 tasks total) covering the full v1.0 implementation
- Link to GitHub Milestone "Code Review Plugin v1.0" with Issues #18-#25
- Fix stale `spec/planning/spec.md` references in `CLAUDE.md` and `PLAN.prompt.md`
- Update `Planner.md` with compilation pipeline, agent configuration, and flat dispatch strategy

## Plan structure

```
plan/code-review-v1/
├── BRIEF.md
└── tasks/
    ├── 01-scaffolding.tasks.md     → #18 (8 tasks)
    ├── 02-shared-prompts.tasks.md  → #19 (7 tasks)
    ├── 03-sre-domain.tasks.md      → #20 (8 tasks)
    ├── 04-security-domain.tasks.md → #21 (8 tasks)
    ├── 05-architecture-domain.tasks.md → #22 (8 tasks)
    ├── 06-data-domain.tasks.md     → #23 (8 tasks)
    ├── 07-code-review-all.tasks.md → #24 (4 tasks)
    └── 08-close.tasks.md           → #25 (8 tasks)
```

## Issue sequence

1. #18 Scaffolding (no dependencies)
2. #19 Shared prompts (depends on #18)
3. #20 SRE — reference implementation (depends on #19)
4. #21 Security, #22 Architecture, #23 Data — parallel (depend on #19)
5. #24 code-review:all (depends on #20-#23)
6. #25 Close milestone (depends on all)

## Test plan

- [ ] Verify all 8 task files have correct issue numbers and dependencies
- [ ] Verify BRIEF.md captures all key architecture decisions from Planner.md
- [ ] Verify each task is atomic and has clear verification criteria
- [ ] Verify GitHub Milestone and Issues are correctly linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)