### PR TITLE
Fix Bash permission patterns for path-based scripts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,8 +24,8 @@
       "Bash(wc:*)",
       "Bash(xargs:*)",
 
-      "Bash(./plugins:*)",
-      "Bash(./scripts:*)",
+      "Bash(./plugins/*)",
+      "Bash(./scripts/*)",
 
       "mcp__ide__getDiagnostics",
 


### PR DESCRIPTION
## Summary

- Fixed `Bash(./plugins:*)` and `Bash(./scripts:*)` permission patterns which used the `:*` suffix (word-boundary match) that only matched commands followed by a space, not path continuations like `./plugins/code-review/scripts/compile.sh`
- Changed to `Bash(./plugins/*)` and `Bash(./scripts/*)` which correctly match any path under those directories

## Context

The `execute-milestone.sh` automation failed in `--permission-mode dontAsk` because the agent needed to run `./plugins/code-review/scripts/compile.sh` but the permission pattern `Bash(./plugins:*)` didn't match — the `:*` syntax enforces a word boundary (space) after the prefix.

## Test plan

- [ ] Run `./scripts/execute-milestone.sh` and verify the agent can execute scripts under `./plugins/` without permission denials

🤖 Generated with [Claude Code](https://claude.com/claude-code)