### PR TITLE
Fix execution prompt to use stacked PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,16 +82,17 @@ Work follows three phases with hard gates between them. **You MUST NOT skip phas
 1. Read the specified task file (e.g., `plan/{milestone}/tasks/01-sre.tasks.md`)
 2. Find the next unchecked `- [ ]` task
 3. Read the task's brief references
-4. Execute the task (create branch if first task, write code, verify)
+4. Execute the task (create branch from base branch if first task in this issue, write code, verify)
 5. Mark the task `- [x]` in the task file
 6. **STOP.** Report what was done. The next invocation picks up the next task.
 
 ### Phase 3: Issue Completion
 
 **Trigger:** All tasks in a task file are `[x]`.
-**Action:** Create PR targeting `main`, referencing the GitHub Issue.
+**Action:** Create a stacked PR targeting the **base branch** (the preceding issue's branch, or `main` for the first issue), referencing the GitHub Issue.
 
 The user then moves to the next task file (next issue) or reviews the PR first.
+When the base PR merges, GitHub automatically retargets the stacked PR.
 
 ### Phase 4: Milestone Completion
 

--- a/EXECUTE.prompt.md
+++ b/EXECUTE.prompt.md
@@ -29,9 +29,10 @@ If ALL tasks in this file are marked `- [x]`, go to **Step 5: Issue Completion**
 
 ### Step 2: Prepare
 
-1. **Check dependencies** — if the task file's **Depends on** lists other issues, verify those PRs have been merged (their deliverable files exist on `main`). If not, STOP and report the blocker.
-2. **Check branch** — if the branch declared in the task file header doesn't exist yet, create it from `main`. If it exists, switch to it.
-3. **Verify predecessor tasks** — confirm that deliverables from earlier tasks in this file exist.
+1. **Determine base branch** — list the task files in `plan/{milestone}/tasks/` in numbered order. If this is the first task file (or `Depends on` is `none`), the base branch is `main`. Otherwise, the base branch is the `Branch` declared in the **immediately preceding** task file. This creates a linear stack regardless of logical dependencies.
+2. **Check dependencies** — if the task file's **Depends on** lists other issues, verify those issues are complete: all tasks in their task files are marked `[x]` and their branches exist. If not, STOP and report the blocker. (In a stacked workflow, dependency PRs are open but not yet merged to `main`.)
+3. **Check branch** — if the branch declared in the task file header doesn't exist yet, create it from the **base branch** (not `main`, unless this is the first task file). If it exists, switch to it.
+4. **Verify predecessor tasks** — confirm that deliverables from earlier tasks in this file exist.
 
 ### Step 3: Execute
 
@@ -63,15 +64,16 @@ Remaining: {count} tasks in this issue
 When all tasks in this task file are `- [x]`:
 
 1. Run any final verification defined in the last task
-2. Push the branch and create a PR against `main`
+2. Push the branch and create a **stacked PR** against the **base branch** (determined in Step 2.1 — `main` for the first issue, the preceding issue's branch for all others)
    - PR title: the issue title
    - PR body: summary of completed tasks, link to the issue with `Closes #{issue-number}`
+   - Note: when the base PR is merged, GitHub automatically retargets the stacked PR to the next base
 3. Report to the user:
 
 ```
 Issue complete: #{issue-number} — {issue title}
 PR: {url}
-Branch: {branch-name}
+Branch: {branch-name} → {base-branch}
 Tasks completed: {count}
 
 Next issue: {next task file name} (or "all issues complete")
@@ -90,7 +92,7 @@ When the task file being processed is the **close-out issue** (`{NN}-close.tasks
    - `spec/README.md` index updated
 3. **Plan directory deleted** by earlier task in this file
 4. **GitHub Milestone closed** by earlier task in this file
-5. Push the branch and create a PR against `main`
+5. Push the branch and create a **stacked PR** against the **base branch** (the preceding issue's branch, continuing the stack)
    - PR title: "Close milestone: {milestone name}"
    - PR body: summary of spec updates, link to milestone, `Closes #{issue-number}`
 6. Report to the user:


### PR DESCRIPTION
## Summary

- **EXECUTE.prompt.md Step 2**: Added "Determine base branch" step — first task file uses `main`, all others use the preceding task file's declared branch. Dependency check now verifies tasks are `[x]` and branches exist (not "merged to main"). Branch creation uses the base branch.
- **EXECUTE.prompt.md Step 5**: PR targets the base branch instead of always `main`, creating stacked PRs that GitHub auto-retargets when base PRs merge.
- **EXECUTE.prompt.md Step 6**: Close-out PR also targets the preceding issue's branch, continuing the stack.
- **CLAUDE.md**: Phase 2 and Phase 3 descriptions updated for consistency.

## Context

When `execute-milestone.sh` runs issues sequentially, issue N+1 depends on code from issue N. But the prompt instructed every issue to branch from `main` and PR against `main` — which fails because issue N's PR hasn't been merged yet. Now each issue branches from the preceding issue's branch, forming a linear PR stack.

## Test plan

- [ ] Verify the prompt instructions are clear and unambiguous by reading through the updated `EXECUTE.prompt.md`
- [ ] Run the execution loop against a milestone with multiple dependent issues and confirm branches chain correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)