### PR TITLE
Fix milestone cleanup committing to main

### DIFF
--- a/scripts/execute-milestone.sh
+++ b/scripts/execute-milestone.sh
@@ -78,6 +78,14 @@ done
 
 MILESTONE_DIR="$(dirname "$PLAN_DIR")"
 
+# Ensure we're on the close-out branch, not main. When all issues were
+# skipped (already complete), the loop never checks out a branch.
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" = "main" ] && [ "$PREV_BRANCH" != "main" ]; then
+  echo "Checking out ${PREV_BRANCH} for cleanup..."
+  git checkout "$PREV_BRANCH"
+fi
+
 if [ -d "$MILESTONE_DIR" ]; then
   echo -e "\033[0;32m=== Milestone cleanup: deleting plan directory ===\033[0m"
   git rm -rf "$MILESTONE_DIR"


### PR DESCRIPTION
## Summary

- When all issues are already complete, `execute-milestone.sh` skips them without checking out any branch — staying on `main`
- The plan directory deletion then commits to `main`, which is rejected by branch protection rules
- Added a check after the loop to checkout the close-out branch (`PREV_BRANCH`) before running cleanup

## Test plan

- [ ] Run `./scripts/execute-milestone.sh` when all issues are complete and on `main` — verify it checks out the close-out branch before cleanup
- [ ] Run `./scripts/execute-milestone.sh` mid-milestone (some issues incomplete) — verify existing behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)