### PR TITLE
feat: maturity visual indicators, HYG→Failure rule, expand HYG abbreviation (v0.2.0)

### DIFF
--- a/plugins/donkey-review/.claude-plugin/plugin.json
+++ b/plugins/donkey-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "donkey-review",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Domain-specific code reviews across Architecture, Security, SRE, and Data Engineering",
   "author": {
     "name": "Donkey Developer"

--- a/plugins/donkey-review/agents/architecture-code.md
+++ b/plugins/donkey-review/agents/architecture-code.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/architecture-landscape.md
+++ b/plugins/donkey-review/agents/architecture-landscape.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/architecture-service.md
+++ b/plugins/donkey-review/agents/architecture-service.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/architecture-system.md
+++ b/plugins/donkey-review/agents/architecture-system.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/data-architecture.md
+++ b/plugins/donkey-review/agents/data-architecture.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/data-engineering.md
+++ b/plugins/donkey-review/agents/data-engineering.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/data-governance.md
+++ b/plugins/donkey-review/agents/data-governance.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/data-quality.md
+++ b/plugins/donkey-review/agents/data-quality.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/security-audit-resilience.md
+++ b/plugins/donkey-review/agents/security-audit-resilience.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/security-authn-authz.md
+++ b/plugins/donkey-review/agents/security-authn-authz.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/security-data-protection.md
+++ b/plugins/donkey-review/agents/security-data-protection.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/security-input-validation.md
+++ b/plugins/donkey-review/agents/security-input-validation.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/sre-availability.md
+++ b/plugins/donkey-review/agents/sre-availability.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/sre-delivery.md
+++ b/plugins/donkey-review/agents/sre-delivery.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/sre-observability.md
+++ b/plugins/donkey-review/agents/sre-observability.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/agents/sre-response.md
+++ b/plugins/donkey-review/agents/sre-response.md
@@ -64,7 +64,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -84,12 +84,12 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Output Format
 
@@ -118,9 +118,13 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass
 
 ## Severity Framework
 
@@ -128,6 +132,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -139,7 +144,7 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.
 
 ## Purpose

--- a/plugins/donkey-review/prompts/shared/maturity-model.md
+++ b/plugins/donkey-review/prompts/shared/maturity-model.md
@@ -9,7 +9,7 @@ Any finding is promoted to `HYG` if it passes any consequence-severity test:
 | **Total** | Can this take down the entire service or cascade beyond its boundary? |
 | **Regulated** | Does this violate a legal or compliance obligation? |
 
-Any "yes" = `HYG`.
+Any "yes" = **HYG (Hygiene Gate)**.
 The Hygiene flag trumps all maturity levels.
 
 ## Maturity Levels
@@ -29,9 +29,9 @@ If a prior level is not passed, subsequent levels are `locked`.
 
 ## Status Indicators
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |

--- a/plugins/donkey-review/prompts/shared/output-format.md
+++ b/plugins/donkey-review/prompts/shared/output-format.md
@@ -25,6 +25,10 @@ This section is **mandatory** — every review must include it.
 
 | Criterion | L1 | L2 | L3 |
 |-----------|----|----|-----|
-| Criterion name | `pass` / `partial` / `fail` | `pass` / `partial` / `fail` / `locked` | `pass` / `partial` / `fail` / `locked` |
+| Criterion name | ✅ Pass | ⚠️ Partial<br>• reason one<br>• reason two | 🔒 Locked |
 
-Mark a level `locked` when the prior level is not `pass`.
+Rules:
+- Use emoji + label for every cell: ✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked
+- Place commentary on a new line using `<br>` and `•` bullets — one bullet per distinct reason; no semi-colon lists
+- If the pillar has any HYG-severity finding, set L1 = ❌ Failure and L2/L3 = 🔒 Locked regardless of criteria assessment
+- Mark a level 🔒 Locked when the prior level is not ✅ Pass

--- a/plugins/donkey-review/prompts/shared/severity-framework.md
+++ b/plugins/donkey-review/prompts/shared/severity-framework.md
@@ -4,6 +4,7 @@ Severity measures **consequence**, not implementation difficulty.
 
 | Level | Merge decision | Meaning |
 |-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
 | **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
 | **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
 | **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
@@ -15,5 +16,5 @@ The shared levels above provide the merge-decision contract; domain prompts supp
 
 ### Interaction with Hygiene Gate
 
-Hygiene findings (`HYG`) always override severity.
+Hygiene Gate findings (`HYG`) always override severity.
 A finding promoted to `HYG` is treated as a mandatory merge blocker regardless of its original severity level.

--- a/spec/review-standards/review-framework.md
+++ b/spec/review-standards/review-framework.md
@@ -147,22 +147,23 @@ Each domain provides its own one-line description that contextualises these leve
 
 Used in maturity assessment tables:
 
-| Indicator | Meaning |
-|-----------|---------|
-| `pass` | All criteria at this level are met |
-| `partial` | Some criteria met, some not |
-| `fail` | No criteria met, or critical criteria missing |
-| `locked` | Previous level not achieved; this level cannot be assessed |
+| Indicator | Symbol | Label | Meaning |
+|-----------|--------|-------|---------|
+| `pass` | ✅ | Pass | All criteria at this level are met |
+| `partial` | ⚠️ | Partial | Some criteria met, some not |
+| `fail` | ❌ | Failure | No criteria met, or critical criteria missing; or pillar has a HYG finding |
+| `locked` | 🔒 | Locked | Previous level not achieved; this level cannot be assessed |
 
 ## Severity Framework
 
-All domains use the same three-level severity structure. Each domain defines its own impact framing.
+All domains use the same severity structure. Each domain defines its own impact framing.
 
-| Level | Merge decision |
-|-------|----------------|
-| **HIGH** | Must fix before merge |
-| **MEDIUM** | May require follow-up ticket |
-| **LOW** | Nice to have |
+| Level | Merge decision | Meaning |
+|-------|----------------|---------|
+| **HYG (Hygiene Gate)** | Mandatory merge blocker | Consequence passes the Irreversible, Total, or Regulated test — fix before this change can proceed. |
+| **HIGH** | Must fix before merge | The change introduces or exposes a material risk that will manifest in production. |
+| **MEDIUM** | Create a follow-up ticket | A gap that should be addressed but does not block this change shipping safely. |
+| **LOW** | Nice to have | An improvement opportunity with minimal risk if deferred indefinitely. |
 
 Severity measures consequence, not implementation difficulty.
 


### PR DESCRIPTION
## Summary

- Replaces plain backtick status labels in the maturity assessment table with emoji + label cells (✅ Pass · ⚠️ Partial · ❌ Failure · 🔒 Locked) and switches inline semicolon commentary to `<br>`-separated bullet points
- Wires the semantic rule that any HYG-severity finding on a pillar forces L1 = ❌ Failure with L2/L3 = 🔒 Locked
- Expands the `HYG` abbreviation to **HYG (Hygiene Gate)** on first use in `maturity-model.md`
- Adds HYG (Hygiene Gate) as the top row of the severity table in both `severity-framework.md` and the spec
- Syncs `spec/review-standards/review-framework.md` Status Indicators and Severity Framework tables to match
- Bumps `plugin.json` from `1.0.0` to `0.2.0`
- Recompiles all 16 agents and 5 skills

## Test plan

- [x] `./plugins/donkey-review/scripts/compile.sh --check` passes — all 21 files in sync
- [ ] Run a review against a codebase with a known HYG finding and confirm L1 renders as `❌ Failure` with L2/L3 as `🔒 Locked`
- [ ] Run a review with no HYG findings and confirm maturity cells use emoji + label with bullet commentary

🤖 Generated with [Claude Code](https://claude.com/claude-code)