### PR TITLE
Bump donkey-review plugin version to v0.3.0

### DIFF
--- a/plugins/donkey-review/.claude-plugin/plugin.json
+++ b/plugins/donkey-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "donkey-review",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Domain-specific code reviews across Architecture, Security, SRE, and Data Engineering",
   "author": {
     "name": "Donkey Developer"


### PR DESCRIPTION
## Summary

- Bumps `donkey-review` plugin version from `0.2.0` to `0.3.0` in `plugin.json`

## Test plan

- [x] Pre-commit hook passes (compiled files are in sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)